### PR TITLE
Added Dockerfile for openshift-ci

### DIFF
--- a/openshift-ci/Dockerfile
+++ b/openshift-ci/Dockerfile
@@ -1,0 +1,18 @@
+FROM registry.access.redhat.com/ubi9/ubi
+
+# rpms required for building and running test suites
+RUN dnf -y install \
+    jq \
+    git \
+    make \
+    gettext \
+    which \
+    skopeo \
+    findutils \
+    gcc \
+    python3 \
+    ansible \
+    diffutils \
+    && dnf clean all
+
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
This is required in order to be able to checkout this repo and have Ansible installed to run the playbooks.