### PR TITLE
Add task to remove sshpass

### DIFF
--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -178,6 +178,13 @@
     ansible_user: "{{ initial_user }}"
     system_rpm_path: "/tmp/{{ system_rpm_link | basename }}"
   tasks:
+
+    - name: Uninstall sshpass
+      become: true  
+      ansible.builtin.dnf:
+        name: sshpass
+        state: absent
+
     - name: Wait 1200 seconds for target connection to become reachable/usable
       ansible.builtin.wait_for_connection:
         delay: 30


### PR DESCRIPTION
Remove sshpass as it uses it to establish a connection using password and not using the ssh private key.

sshpass with the presence of ansible_password in the inventory will try to establish a connection using a password.

` EXEC sshpass -d50 ssh -vvv -o UserKnownHostsFile=/dev/null` is a part of the command that was running.