### PR TITLE
fix issue where the create VM fails due to missing line break on bash…

### DIFF
--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -169,7 +169,7 @@
       ansible.builtin.import_role:
         name: redhatci.ocp.create_vms
       vars:
-        additional_virt_install_options: "--cloud-init network-config=/tmp/{{ vm_name }}-network.yaml --wait=0"
+        additional_virt_install_options: "--cloud-init network-config=/tmp/{{ vm_name }}-network.yaml --wait=0 \\"
         cluster_name: "dummy"
         vm_bridge_name: default
         images_dir: "{{ libvirtd_disk_path }}"


### PR DESCRIPTION
when to `create-vm.sh` script is created [here](https://github.com/redhatci/ansible-collection-redhatci-ocp/blob/main/roles/create_vms/templates/create_vm.sh.j2#L36)

script fails due to missing line break at the end
```bash
# /home/redhat/initial-executor-tlv-1_setup_vm.sh
...
    --noautoconsole \
    --wait=-1 \
    --cloud-init network-config=/tmp/initial-executor-tlv-1-network.yaml --wait=0
    --events on_reboot=restart \
    --autostart \
...
```