### PR TITLE
NO-ISSUE: fix kvm spec use default settings

### DIFF
--- a/playbooks/deploy-ocp-hybrid-multinode.yml
+++ b/playbooks/deploy-ocp-hybrid-multinode.yml
@@ -77,6 +77,16 @@
         network_config: "{{ network_config_string | from_yaml }}"
         mac_interface_map: "{{ mac_interface_map_string | from_yaml }}"
 
+    - name: Render VM spec from YAML string
+      ansible.builtin.set_fact:
+        vm_spec: "{{ vm_spec_string | from_yaml }}"
+        network_interfaces: "{{ network_interfaces_string | from_yaml }}"
+      when: vendor | lower == 'kvm'
+
+    - name: Process KVM nodes to set facts
+      ansible.builtin.import_role:
+        name: redhatci.ocp.process_kvm_nodes
+
 # Process optional environment Variables if present
 - name: Mutate worker network configuration if env variables are present
   hosts: workers
@@ -231,10 +241,6 @@
         gai_discovery_iso_name: "agent.iso"
         gai_remote_http_src: true
         gai_http_delegate_host: "{{ inventory_hostname }}"
-
-    - name: Process KVM nodes to set facts
-      ansible.builtin.import_role:
-        name: redhatci.ocp.process_kvm_nodes
 
 - name: Setup Virtual Control Plane
   hosts: vm_hosts

--- a/playbooks/roles/oc_client_install/tasks/oc_install.yml
+++ b/playbooks/roles/oc_client_install/tasks/oc_install.yml
@@ -106,10 +106,12 @@
     - "kubectl"
 
 - name: Verify 'oc' binary by running 'oc version'
-  ansible.builtin.command: oc version
+  ansible.builtin.command: oc version --client=false
   register: oc_check
   ignore_errors: true
   changed_when: false
+  environment:
+    KUBECONFIG: ""
 
 - name: Fail if 'oc' binary is missing or not executable
   when: oc_check.rc != 0


### PR DESCRIPTION
- when deploying workers / masters the cpu and memory are not been
  processed
- workaround setting KUBECONFIG to empty value
- enabling Ansible pipelining

Signed-off-by: Eran Ifrach <eifrach@redhat.com>