### PR TITLE
NO-ISSUE: fix issue where failling due miss kubeconfig

### DIFF
--- a/playbooks/deploy-ocp-hybrid-multinode.yml
+++ b/playbooks/deploy-ocp-hybrid-multinode.yml
@@ -305,6 +305,10 @@
         mabi_retry_install_complete_check: true
         cluster: "{{ cluster_name }}"
 
+    - name: Set Kubeconfig
+      ansible.builtin.set_fact:
+        kubeconfig: "~/project/generated/{{ cluster_name }}/auth/kubeconfig"
+
     - name: Get OpenShift pull-secret
       kubernetes.core.k8s_info:
         api_version: v1

--- a/playbooks/roles/oc_client_install/tasks/oc_install.yml
+++ b/playbooks/roles/oc_client_install/tasks/oc_install.yml
@@ -106,14 +106,12 @@
     - "kubectl"
 
 - name: Verify 'oc' binary by running 'oc version'
-  ansible.builtin.command: oc version --client=false
+  ansible.builtin.command: oc version -o json
   register: oc_check
   ignore_errors: true
   changed_when: false
-  environment:
-    KUBECONFIG: ""
 
 - name: Fail if 'oc' binary is missing or not executable
-  when: oc_check.rc != 0
+  when: (oc_check.stdout | from_json)['clientVersion']['buildDate'] is not defined
   ansible.builtin.fail:
     msg: "'oc' binary is missing or not executable!"


### PR DESCRIPTION
- changing `oc version` to look for a string instead of exit status
- setting kubeconfig location before accessing cluster

Signed-off-by: Eran Ifrach <eifrach@redhat.com>