### PR TITLE
reformat requirements.yml

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,7 +1,6 @@
 ---
 skip_list:
   - var-naming[no-role-prefix]
-  - name[unique]
 
 # Define paths or files to ignore
 exclude_paths:

--- a/playbooks/cnf/deploy-cnf-config.yaml
+++ b/playbooks/cnf/deploy-cnf-config.yaml
@@ -89,8 +89,6 @@
         kind: Network
         name: cluster
         patch: "{{ cluster_network_patch }}"
-      tags:
-        - skip_ansible_lint
 
     - name: Wait for network operator update to begin
       kubernetes.core.k8s_info:
@@ -175,7 +173,7 @@
             state: present
             definition: "{{ lookup('template', 'templates/mc_add_ip.j2') }}"
 
-        - name: Wait for MachineConfigPool update
+        - name: Wait for MachineConfigPool update (post IP assignment)
           ansible.builtin.import_tasks: tasks/wait_for_mcp.yaml
           vars:
             mcp_name: "{{ cnf_nodes_role }}"
@@ -213,7 +211,7 @@
         state: present
         definition: "{{ lookup('template', 'templates/worker_cnf_machine_config_pool.j2') }}"
 
-    - name: Wait for MachineConfigPool update
+    - name: Wait for MachineConfigPool update (post CNF MachineConfigPool creation)
       ansible.builtin.import_tasks: tasks/wait_for_mcp.yaml
       vars:
         mcp_name: "{{ cnf_nodes_role }}"
@@ -223,7 +221,7 @@
         state: present
         definition: "{{ lookup('template', 'templates/sctp_load_mc.j2') }}"
 
-    - name: Wait for MachineConfigPool update
+    - name: Wait for MachineConfigPool update (post SCTP module enablement)
       ansible.builtin.import_tasks: tasks/wait_for_mcp.yaml
       vars:
         mcp_name: "{{ cnf_nodes_role }}"
@@ -233,12 +231,12 @@
         state: present
         definition: "{{ lookup('template', 'templates/xt-u32-load-module.j2') }}"
 
-    - name: Final MachineConfigPool synchronization
+    - name: Wait for MachineConfigPool update (post xt-u32 module enablement)
       ansible.builtin.import_tasks: tasks/wait_for_mcp.yaml
       vars:
         mcp_name: "{{ cnf_nodes_role }}"
 
-    - name: Store additiona CA cert in variable
+    - name: Store additional CA cert in variable
       ansible.builtin.uri:
         url: "{{ ca_update_link }}"
         method: GET

--- a/playbooks/cnf/switch-config.yaml
+++ b/playbooks/cnf/switch-config.yaml
@@ -141,23 +141,23 @@
       ansible.builtin.set_fact:
         env_var_vlans: "{{ vlan_list | join(',') }}"
 
-    - name: Prepare external VLAN variables
+    - name: Update shell_script code with VLAN env variable
       ansible.builtin.set_fact:
         shell_script: |
           {{ shell_script }}
           export VLAN="{{ env_var_vlans }}"
 
-    - name: Set INTERFACE_LIST env variable
+    - name: Update shell_script code with INTERFACE_LIST env variable
       ansible.builtin.set_fact:
         shell_script: |
           {{ shell_script }}
           export INTERFACE_LIST="{{ cluster_config[cluster_name]['bm_interface_list'][secondary_nic] | quote }}"
 
-    - name: Set SWITCH_INTERFACES env variable
+    - name: Set switch_interfaces fact (for SWITCH_INTERFACES env variable)
       ansible.builtin.set_fact:
         switch_interfaces: "{{ cluster_config[cluster_name][secondary_nic] | map(attribute='switch_interface') | list }}"
 
-    - name: Set SWITCH_INTERFACES env variable
+    - name: Update shell_script code with SWITCH_INTERFACES env variable
       ansible.builtin.set_fact:
         shell_script: |
           {{ shell_script }}

--- a/playbooks/setup-cluster-env.yml
+++ b/playbooks/setup-cluster-env.yml
@@ -105,7 +105,7 @@
       ansible.builtin.debug:
         msg: "Primary OCP NIC is: {{ ocp_primary_nic }}"
 
-    - name: Write OCP secondary NIC parameter to file
+    - name: Write OCP primary NIC parameter to file
       ansible.builtin.copy:
         content: "{{ ocp_primary_nic }}"
         dest: "{{ dest_directory }}/{{ ocp_primary_nic_file_name }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,10 +1,10 @@
 ---
 collections:
   - name: community.libvirt
-    version: "1.3.0"
+    version: 1.3.0
   - name: redhatci.ocp
-    version: "2.5.1749150845"
+    version: 2.5.1749150845
   - name: kubernetes.core
-    version: "2.4.2"
+    version: 2.4.2
   - name: junipernetworks.junos
-    version: "9.1.0"
+    version: 9.1.0


### PR DESCRIPTION
clean up `requirements.yml` quotation marks in `version` key values for:
1. ease of playbook dev process
1. resulting in smaller diffs after it