### PR TITLE
Add polarion url to upload-report playbook and to Slack msg

### DIFF
--- a/playbooks/cnf/upload-report.yaml
+++ b/playbooks/cnf/upload-report.yaml
@@ -157,6 +157,12 @@
         - Remove stopped containers
         - Remove reporter project dir
 
+    - name: Copy polarion URL to shared directory
+      ansible.builtin.copy:
+        src: "{{ reporter_project_root_dir }}/{{ reporter_project_dest_dir }}/.polarion_url"
+        dest: "{{ shared_dir }}/polarion_url.txt"
+        mode: "0777"
+
   handlers:
 
     - name: Remove reports dir

--- a/scripts/send-slack-notification-bot.py
+++ b/scripts/send-slack-notification-bot.py
@@ -16,6 +16,7 @@ def send_to_slack(webhook_url, release_info, prow_job_url):
 
 Links:
 - Jira: {release_info['jira_card_link']}
+- Polarion: {release_info['polarion_url']}
 - Prow Job: <{prow_job_url}|View Prow Job>
 
 Environment:
@@ -78,6 +79,7 @@ def main():
     release_info = {
         "version": version,
         "jira_card_link": read_file_content(os.path.join(shared_dir, "jira_link")),
+        "polarion_url": read_file_content(os.path.join(shared_dir, "polarion_url.txt")),
         "test_env": {
             "cluster_name": read_file_content(os.path.join(shared_dir, "cluster_name")),
             "nic": read_file_content(os.path.join(shared_dir, "ocp_nic")),


### PR DESCRIPTION
Add Polarion URL to CNF upload-report playbook and FT Network Slack notification

This change integrates Polarion URL sharing between the upload-report 
playbook and Slack notifications:

- Copy Polarion URL from reporter project to shared directory in upload-report.yaml
- Include Polarion URL in Slack notification messages via send-slack-notification-bot.py

Dependencies:
- Requires cnf-polarion project changes that enable saving .polarion_url file - https://gitlab.cee.redhat.com/cnf/cnf-polarion/-/merge_requests/53
- Follow-up PR needed for release repo to pass SHARED_DIR environment variable

cc: @kononovn 
