### PR TITLE
TELCOV10N-682: Randomize folder path

### DIFF
--- a/playbooks/infra/roles/kickstart_iso/defaults/main.yml
+++ b/playbooks/infra/roles/kickstart_iso/defaults/main.yml
@@ -2,6 +2,6 @@
 # defaults file for kickstart_iso
 kickstart_iso_dest_dir: "/tmp"
 kickstart_iso_mount_path: "/tmp/mount"
-kickstart_iso_os_install_path: "/tmp/os-install"
-kickstart_iso_name: "installation.iso"
+kickstart_iso_os_install_path_basename: "/tmp/os-install"
+kickstart_iso_basename: "installation.iso"
 kickstart_iso_link: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-41-1.4.iso"

--- a/playbooks/infra/roles/kickstart_iso/tasks/main.yml
+++ b/playbooks/infra/roles/kickstart_iso/tasks/main.yml
@@ -31,6 +31,14 @@
     opts: ro
     state: ephemeral
 
+- name: Get suffix for filename
+  ansible.builtin.set_fact:
+    generated_suffix: lookup('community.general.random_string', upper=false, numbers=false,length=5, special=false)
+
+- name: Set kickstart iso os install path
+  ansible.builtin.set_fact:
+    kickstart_iso_os_install_path: "{{ kickstart_iso_os_install_path_basename }}-{{ generated_suffix }}"
+
 - name: Create working directory
   ansible.builtin.file:
     state: directory
@@ -117,6 +125,10 @@
               linuxefi /images/pxeboot/vmlinuz inst.stage2=hd:LABEL={{ volume_name.stdout }} inst.ks=hd:LABEL={{ volume_name.stdout }}:/ks.cfg
               initrdefi /images/pxeboot/initrd.img
       }
+
+- name: Set kickstart iso name
+  ansible.builtin.set_fact:
+    kickstart_iso_name: "{{ kickstart_iso_basename }}-{{ generated_suffix }}"
 
 - name: Create bootable iso
   become: true


### PR DESCRIPTION
- create a random name for the working folder, which allow us to run more than one installation without conflicts