### PR TITLE
feat: parameterize workload hints in performance profile template

### DIFF
--- a/playbooks/compute/nto/roles/configurecluster/defaults/main.yml
+++ b/playbooks/compute/nto/roles/configurecluster/defaults/main.yml
@@ -3,6 +3,8 @@ mcp_timeout: 10m
 artifacts_folder: /artifacts
 ignore_cgroups_version: "true"
 rt_kernel: false
+high_power_consumption: false
+per_pod_power_management: false
 must_gather_dir: "/mustgather"
 container_runtime: "runc"
 nto_image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuning-rhel9-operator

--- a/playbooks/compute/nto/roles/configurecluster/templates/performanceProfile.yml.j2
+++ b/playbooks/compute/nto/roles/configurecluster/templates/performanceProfile.yml.j2
@@ -33,6 +33,6 @@ spec:
     realTimeKernel:
         enabled:  {{ rt_kernel }}
     workloadHints:
-        highPowerConsumption: true
-        perPodPowerManagement: false
+        highPowerConsumption: {{ high_power_consumption }}
+        perPodPowerManagement: {{ per_pod_power_management }}
         realTime: {{ rt_kernel }}


### PR DESCRIPTION
- Add high_power_consumption and per_pod_power_management variables to role defaults
- Update performanceProfile.yml.j2 to use variables instead of hardcoded values
- Both parameters default to false for conservative performance profile
- Follows same pattern as existing rt_kernel parameter