### PR TITLE
Role `junit2json` and its infrastructure

### DIFF
--- a/playbooks/infra/reporting/roles/junit2json/README.md
+++ b/playbooks/infra/reporting/roles/junit2json/README.md
@@ -1,0 +1,425 @@
+<!-- DOCSIBLE START -->
+
+# 📃 Role overview
+
+## junit2json
+
+Description: Converts XML junit reports passed or in passed directory into single or fragmented JSON report file(s)
+
+<details>
+<summary><b>🧩 Argument Specifications in meta/argument_specs</b></summary>
+
+### Key: main
+
+**Description**: The resulting JSON file(s) are of the same structure for all the teams' and CI systems
+and later used to be sent to the data collection system. This is the main entrypoint
+for the role `junit2json`. Converts XMLs into JSON, if variable `junit2_do_merge` is `true`,
+multiple XMLs are merged into one XML file.
+Outputs:
+
+- merged filename location is stored in the variable `junit2_output_merged_report`.
+- variable `junit2_json_reports_list` contains list of all converted JSON file names
+It is user's responsibility to consumer the right variable(s) in the next role(s).
+
+- **junit2_input_reports_list**
+  - **Required**: True
+  - **Type**: list
+  - **Default**: none
+  - **Description**: List of JUnit XML report files to convert to JSON
+
+- **junit2_do_merge**
+  - **Required**: False
+  - **Type**: bool
+  - **Default**: True
+  - **Description**: Should we merge data of converted reports into 1 file or not. When `false`, each report `XML` file
+is converted to a corresponding json file appended `.json` extension.
+Otherwise, resulting merged report is named as the directory, with `.report.json` extension.
+In both cases, the result is stored under `junit2_output_dir`.
+
+- **junit2_output_dir**
+  - **Required**: True
+  - **Type**: str
+  - **Default**: none
+  - **Description**: Output directory for resulting report JSON file path(s)
+
+- **junit2_input_merged_report**
+  - **Required**: False
+  - **Type**: str
+  - **Default**: merged.junit.xml
+  - **Description**: Relative file name for the Merged XML report (relevant only when `junit2_do_merge` is `true`),
+it is generated under `junit2_output_dir`
+
+- **junit2_output_merged_report**
+  - **Required**: False
+  - **Type**: str
+  - **Default**: merged.junit.json
+  - **Description**: Relative file name for the JSON report (relevant only when `junit2_do_merge` is `true`),
+it is generated under `junit2_output_dir`
+
+- **junit2_json_reports_list**
+  - **Required**: False
+  - **Type**: list
+  - **Default**: []
+  - **Description**: This is the output variable updated by the role for the converted JSON reports file names.
+If it is defined outside of the role, the role updates it.
+
+- **junit2_out_str**
+  - **Required**: False
+  - **Type**: bool
+  - **Default**: True
+  - **Description**: If true, the call to filter should pass object=true, otherwise object=false is passed.
+
+</details>
+
+### Defaults
+
+#### These are static variables with lower priority
+
+#### File: `defaults/main.yml`
+
+| Var          | Type         | Value       |Required    | Title       |
+|--------------|--------------|-------------|-------------|-------------|
+| [junit2_custom_dummy_variables](defaults/main.yml#L7)   | dict   | `{}` |    n/a  |  n/a |
+| [junit2_dummy_debug](defaults/main.yml#L10)   | bool   | `False` |    n/a  |  n/a |
+| [junit2_input_merged_report](defaults/main.yml#L13)   | str   | `merged.junit.xml` |    n/a  |  n/a |
+| [junit2_output_merged_report](defaults/main.yml#L14)   | str   | `merged.junit.json` |    n/a  |  n/a |
+| [junit2_do_merge](defaults/main.yml#L15)   | bool   | `True` |    n/a  |  n/a |
+| [junit2_out_str](defaults/main.yml#L16)   | bool   | `True` |    n/a  |  n/a |
+
+### Vars
+
+#### These are variables with higher priority
+
+#### File: `vars/dummy_variables.yml`
+
+| Var          | Type         | Value       |Required    | Title       |
+|--------------|--------------|-------------|-------------|-------------|
+| [junit2_dummy_variables](vars/dummy_variables.yml#L9)   | dict   | `{'expectation_failed': 'PLACEHOLDER_EXPECTATION_FAILED', 'job_info': {'job': {'id': 'PLACEHOLDER_JOB_ID', 'name': 'PLACEHOLDER_JOB_NAME', 'url': 'PLACEHOLDER_JOB_URL'}, 'build': {'number': 'PLACEHOLDER_BUILD_NUMBER', 'url': 'PLACEHOLDER_BUILD_URL'}}, 'ci_job_id': 'PLACEHOLDER_CI_JOB_ID', 'ci_build_id': 'PLACEHOLDER_CI_BUILD_ID', 'ci_pipeline_id': 'PLACEHOLDER_CI_PIPELINE_ID', 'test_environment': 'PLACEHOLDER_TEST_ENV', 'cluster_name': 'PLACEHOLDER_CLUSTER_NAME', 'namespace': 'PLACEHOLDER_NAMESPACE', 'error_message': 'PLACEHOLDER_ERROR_MESSAGE', 'failure_reason': 'PLACEHOLDER_FAILURE_REASON', 'exception_details': 'PLACEHOLDER_EXCEPTION_DETAILS', 'timestamp': 'PLACEHOLDER_TIMESTAMP', 'test_start_time': 'PLACEHOLDER_TEST_START_TIME', 'test_end_time': 'PLACEHOLDER_TEST_END_TIME'}` |    n/a  |  n/a |
+
+### Tasks
+
+#### File: ``tasks/convert.yml``
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Read file content | ansible.builtin.set_fact | False |
+| Update junit2_result_data junit2_do_merge=true | ansible.builtin.set_fact | False |
+| Setup JSON report file name | ansible.builtin.set_fact | False |
+| Set junit2_output_report_path | ansible.builtin.set_fact | False |
+| Update output variable junit2_json_reports_list | ansible.builtin.set_fact | False |
+| Ensure junit2_output_dir is created | ansible.builtin.include_tasks | False |
+| Write the json object to file | ansible.builtin.copy | True |
+| Write the json string to file | ansible.builtin.copy | True |
+
+#### File: ``tasks/merge.yml``
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Load dummy variables configuration | ansible.builtin.include_vars | False |
+| Merge custom dummy variables with defaults | ansible.builtin.set_fact | True |
+| Debug dummy variables being set | ansible.builtin.debug | True |
+| Set dummy variables for template strings in test data | ansible.builtin.set_fact | True |
+| Ensure junit2_output_dir is created | ansible.builtin.include_tasks | False |
+| Merge multiple JSON report files into single consolidated report | ansible.builtin.set_fact | False |
+| Debug merged file path | ansible.builtin.debug | False |
+
+#### File: `tasks/ensure-dir.yml`
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Collect folder_path stat | ansible.builtin.stat | False |
+| Ensure missing folder_path is created | ansible.builtin.file | True |
+
+#### File: `tasks/expand.yml`
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Print file_name value | ansible.builtin.debug | False |
+| Collect file_name stat | ansible.builtin.stat | False |
+| Verify file_name exists and is a regular file | ansible.builtin.assert | False |
+| Update junit2_reports_list with a JUnit XML report item | ansible.builtin.set_fact | True |
+
+#### File: `tasks/main.yml`
+
+| Name | Module | Has Conditions |
+| ---- | ------ | --------- |
+| Validate role variables | ansible.builtin.assert | False |
+| Print input reports variable | ansible.builtin.debug | False |
+| Initialize reports variable | ansible.builtin.set_fact | False |
+| Expand the input list to list of existing files | ansible.builtin.include_tasks | False |
+| Convert XML to JSON | ansible.builtin.include_tasks | True |
+| Merge JUnit XML reports into one file junit2_do_merge=true | ansible.builtin.include_tasks | True |
+
+## Task Flow Graphs
+
+### Graph for convert.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Read_file_content0[read file content]:::task
+  Read_file_content0-->|Task| Update_junit2_result_data_junit2_do_merge_true1[update junit2 result data junit2 do merge true]:::task
+  Update_junit2_result_data_junit2_do_merge_true1-->|Task| Setup_JSON_report_file_name2[setup json report file name]:::task
+  Setup_JSON_report_file_name2-->|Task| Set_junit2_output_report_path3[set junit2 output report path]:::task
+  Set_junit2_output_report_path3-->|Task| Update_output_variable_junit2_json_reports_list4[update output variable junit2 json reports list]:::task
+  Update_output_variable_junit2_json_reports_list4-->|Include task| ensure_dir_yml5[ensure junit2 output dir is created<br>include_task: ensure dir yml]:::includeTasks
+  ensure_dir_yml5-->|Task| Write_the_json_object_to_file6[write the json object to file<br>When: **not junit2 out str   bool**]:::task
+  Write_the_json_object_to_file6-->|Task| Write_the_json_string_to_file7[write the json string to file<br>When: **junit2 out str   bool**]:::task
+  Write_the_json_string_to_file7-->End
+```
+
+### Graph for merge.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Include vars| dummy_variables_yml0[load dummy variables configuration<br>include_vars: dummy variables yml]:::includeVars
+  dummy_variables_yml0-->|Task| Merge_custom_dummy_variables_with_defaults1[merge custom dummy variables with defaults<br>When: **junit2 custom dummy variables   length   0 and<br>junit2 dummy variables   default       length   0**]:::task
+  Merge_custom_dummy_variables_with_defaults1-->|Task| Debug_dummy_variables_being_set2[debug dummy variables being set<br>When: **junit2 dummy debug   bool and junit2 dummy<br>variables   default       length   0**]:::task
+  Debug_dummy_variables_being_set2-->|Task| Set_dummy_variables_for_template_strings_in_test_data3[set dummy variables for template strings in test<br>data<br>When: **vars item key  is not defined and junit2 dummy<br>variables   default       length   0**]:::task
+  Set_dummy_variables_for_template_strings_in_test_data3-->|Include task| ensure_dir_yml4[ensure junit2 output dir is created<br>include_task: ensure dir yml]:::includeTasks
+  ensure_dir_yml4-->|Task| Merge_multiple_JSON_report_files_into_single_consolidated_report5[merge multiple json report files into single<br>consolidated report]:::task
+  Merge_multiple_JSON_report_files_into_single_consolidated_report5-->|Task| Debug_merged_file_path6[debug merged file path]:::task
+  Debug_merged_file_path6-->End
+```
+
+### Graph for ensure-dir.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Collect_folder_path_stat0[collect folder path stat]:::task
+  Collect_folder_path_stat0-->|Task| Ensure_missing_folder_path_is_created1[ensure missing folder path is created<br>When: **not  junit2 folder path stat stat isdir   default<br>false**]:::task
+  Ensure_missing_folder_path_is_created1-->End
+```
+
+### Graph for expand.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Print_file_name_value0[print file name value]:::task
+  Print_file_name_value0-->|Task| Collect_file_name_stat1[collect file name stat]:::task
+  Collect_file_name_stat1-->|Task| Verify_file_name_exists_and_is_a_regular_file2[verify file name exists and is a regular file]:::task
+  Verify_file_name_exists_and_is_a_regular_file2-->|Task| Update_junit2_reports_list_with_a_JUnit_XML_report_item3[update junit2 reports list with a junit xml report<br>item<br>When: **junit2json path item stat stat exists   default<br>false**]:::task
+  Update_junit2_reports_list_with_a_JUnit_XML_report_item3-->End
+```
+
+### Graph for main.yml
+
+```mermaid
+flowchart TD
+Start
+classDef block stroke:#3498db,stroke-width:2px;
+classDef task stroke:#4b76bb,stroke-width:2px;
+classDef includeTasks stroke:#16a085,stroke-width:2px;
+classDef importTasks stroke:#34495e,stroke-width:2px;
+classDef includeRole stroke:#2980b9,stroke-width:2px;
+classDef importRole stroke:#699ba7,stroke-width:2px;
+classDef includeVars stroke:#8e44ad,stroke-width:2px;
+classDef rescue stroke:#665352,stroke-width:2px;
+
+  Start-->|Task| Validate_role_variables0[validate role variables]:::task
+  Validate_role_variables0-->|Task| Print_input_reports_variable1[print input reports variable]:::task
+  Print_input_reports_variable1-->|Task| Initialize_reports_variable2[initialize reports variable]:::task
+  Initialize_reports_variable2-->|Include task| expand_yml3[expand the input list to list of existing files<br>include_task: expand yml]:::includeTasks
+  expand_yml3-->|Include task| convert_yml4[convert xml to json<br>When: **junit2 reports list   length   0**<br>include_task: convert yml]:::includeTasks
+  convert_yml4-->|Include task| merge_yml5[merge junit xml reports into one file junit2 do<br>merge true<br>When: **junit2 do merge and junit2 json reports list  <br>length   0**<br>include_task: merge yml]:::includeTasks
+  merge_yml5-->End
+```
+
+## Playbook
+
+```yml
+---
+
+- name: Test junit2json role - simple input
+  hosts: localhost
+  connection: local
+  vars:
+    junit2_output_merged_report: 'merged.junit.json'
+  tasks:
+    - name: Run tests for both values of junit2_out_str
+      block:
+        - name: Test role junit2json without merge junit2_out_str=true
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ role_path }}/tests/unit/data/test_junit2obj_simple_input.xml"
+            junit2_output_dir: "{{ role_path }}"
+            junit2_do_merge: false
+            junit2_out_str: true
+
+        - name: Load actual result into variable actual junit2_out_str=true
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', role_path + '/tests/unit/data/test_junit2obj_simple_input.json') | from_json }}"
+
+        - name: Load expected result into variable expected junit2_out_str=true
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', role_path + '/tests/unit/data/test_junit2obj_simple_result.json') }}"
+
+        - name: Ensure test passes junit2_out_str=true
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+        - name: Reset global variable junit2_out_str=true
+          ansible.builtin.set_fact:
+            junit2_json_reports_list: []
+
+        - name: Test role junit2json with merge junit2_out_str=true
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ role_path }}/tests/unit/data/test_junit2obj_simple_input.xml"
+              - "{{ role_path }}/tests/unit/data/test_junit2obj_failure_input.xml"
+            junit2_output_dir: "{{ role_path }}/tests"
+            junit2_do_merge: true
+            junit2_out_str: true
+
+        - name: Load actual result into variable actual junit2_out_str=true
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', junit2_result_merged_file) | from_json }}"
+
+        - name: Load expected result into variable expected junit2_out_str=true
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', role_path + '/tests/unit/data/' + junit2_output_merged_report) }}"
+
+        - name: Ensure test passes junit2_out_str=true
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+        - name: Test role junit2json without merge junit2_out_str=false
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ role_path }}/tests/unit/data/test_junit2obj_simple_input.xml"
+            junit2_output_dir: "{{ role_path }}/tests"
+            junit2_do_merge: false
+            junit2_out_str: false
+
+        - name: Load actual result into variable actual junit2_out_str=false
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', role_path + '/tests/unit/data/test_junit2obj_simple_input.json') | from_json }}"
+
+        - name: Load expected result into variable expected junit2_out_str=false
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', role_path + '/tests/unit/data/test_junit2obj_simple_result.json') }}"
+
+        - name: Ensure test passes junit2_out_str=false
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+        - name: Reset global variable junit2_out_str=false
+          ansible.builtin.set_fact:
+            junit2_json_reports_list: []
+
+        - name: Test role junit2json with merge junit2_out_str=false
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ role_path }}/tests/unit/data/test_junit2obj_simple_input.xml"
+              - "{{ role_path }}/tests/unit/data/test_junit2obj_failure_input.xml"
+            junit2_output_dir: "{{ role_path }}/tests"
+            junit2_do_merge: true
+            junit2_out_str: false
+
+        - name: Load actual result into variable actual junit2_out_str=false
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', junit2_result_merged_file) | from_json }}"
+
+        - name: Load expected result into variable expected junit2_out_str=false
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', role_path + '/tests/unit/data/' + (junit2_result_merged_file | basename)) }}"
+
+        - name: Ensure test passes junit2_out_str=false
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+```
+
+## Playbook graph
+
+```mermaid
+flowchart TD
+  localhost-->|Block Start| Run_tests_for_both_values_of_junit2_out_str0_block_start_0[[run tests for both values of junit2 out str]]:::block
+  Run_tests_for_both_values_of_junit2_out_str0_block_start_0-->|Include role| junit2json0(test role junit2json without merge junit2 out str<br>true<br>include_role: junit2json):::includeRole
+  junit2json0-->|Task| Load_actual_result_into_variable_actual_junit2_out_str_true1[load actual result into variable actual junit2 out<br>str true]:::task
+  Load_actual_result_into_variable_actual_junit2_out_str_true1-->|Task| Load_expected_result_into_variable_expected_junit2_out_str_true2[load expected result into variable expected junit2<br>out str true]:::task
+  Load_expected_result_into_variable_expected_junit2_out_str_true2-->|Task| Ensure_test_passes_junit2_out_str_true3[ensure test passes junit2 out str true]:::task
+  Ensure_test_passes_junit2_out_str_true3-->|Task| Reset_global_variable_junit2_out_str_true4[reset global variable junit2 out str true]:::task
+  Reset_global_variable_junit2_out_str_true4-->|Include role| junit2json5(test role junit2json with merge junit2 out str<br>true<br>include_role: junit2json):::includeRole
+  junit2json5-->|Task| Load_actual_result_into_variable_actual_junit2_out_str_true6[load actual result into variable actual junit2 out<br>str true]:::task
+  Load_actual_result_into_variable_actual_junit2_out_str_true6-->|Task| Load_expected_result_into_variable_expected_junit2_out_str_true7[load expected result into variable expected junit2<br>out str true]:::task
+  Load_expected_result_into_variable_expected_junit2_out_str_true7-->|Task| Ensure_test_passes_junit2_out_str_true8[ensure test passes junit2 out str true]:::task
+  Ensure_test_passes_junit2_out_str_true8-->|Include role| junit2json9(test role junit2json without merge junit2 out str<br>false<br>include_role: junit2json):::includeRole
+  junit2json9-->|Task| Load_actual_result_into_variable_actual_junit2_out_str_false10[load actual result into variable actual junit2 out<br>str false]:::task
+  Load_actual_result_into_variable_actual_junit2_out_str_false10-->|Task| Load_expected_result_into_variable_expected_junit2_out_str_false11[load expected result into variable expected junit2<br>out str false]:::task
+  Load_expected_result_into_variable_expected_junit2_out_str_false11-->|Task| Ensure_test_passes_junit2_out_str_false12[ensure test passes junit2 out str false]:::task
+  Ensure_test_passes_junit2_out_str_false12-->|Task| Reset_global_variable_junit2_out_str_false13[reset global variable junit2 out str false]:::task
+  Reset_global_variable_junit2_out_str_false13-->|Include role| junit2json14(test role junit2json with merge junit2 out str<br>false<br>include_role: junit2json):::includeRole
+  junit2json14-->|Task| Load_actual_result_into_variable_actual_junit2_out_str_false15[load actual result into variable actual junit2 out<br>str false]:::task
+  Load_actual_result_into_variable_actual_junit2_out_str_false15-->|Task| Load_expected_result_into_variable_expected_junit2_out_str_false16[load expected result into variable expected junit2<br>out str false]:::task
+  Load_expected_result_into_variable_expected_junit2_out_str_false16-->|Task| Ensure_test_passes_junit2_out_str_false17[ensure test passes junit2 out str false]:::task
+  Ensure_test_passes_junit2_out_str_false17-.->|End of Block| Run_tests_for_both_values_of_junit2_out_str0_block_start_0
+```
+
+## Author Information
+
+Max Kovgan
+
+### License
+
+Apache-2.0
+
+### Minimum Ansible Version
+
+2.9
+
+### Platforms
+
+No platforms specified.
+<!-- DOCSIBLE END -->

--- a/playbooks/infra/reporting/roles/junit2json/defaults/main.yml
+++ b/playbooks/infra/reporting/roles/junit2json/defaults/main.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Default variables for junit2json role
+
+# Custom dummy variables (will be merged with defaults from vars/dummy_variables.yml)
+# Use this to add project-specific template placeholders
+junit2_custom_dummy_variables: {}
+
+# Enable verbose logging for dummy variable processing
+junit2_dummy_debug: false
+
+# Original role defaults (preserved for compatibility)
+junit2_input_merged_report: "merged.junit.xml"
+junit2_output_merged_report: "merged.junit.json"
+junit2_do_merge: true
+junit2_out_str: true

--- a/playbooks/infra/reporting/roles/junit2json/doc/dummy_variables.md
+++ b/playbooks/infra/reporting/roles/junit2json/doc/dummy_variables.md
@@ -1,0 +1,96 @@
+# Template Handling in junit2json Role
+
+## The Problem
+
+Test data sometimes contains literal strings that look like Jinja2 templates:
+
+```xml
+<testcase name="... expectations failed: {{ expectation_failed }}" />
+<testcase name="... log at: https://ci.example.com/jobs/{{ job_info.job.id }}/states" />
+```
+
+When Ansible processes this data, it tries to evaluate these as templates, causing:
+
+```
+ERROR! 'expectation_failed' is undefined
+ERROR! 'job_info' is undefined
+```
+
+## The Solution
+
+The role provides dummy variables for template patterns. Which method you use depends on **variable frequency** and **your maintenance access**:
+
+## Adding Dummy Variables
+
+### High Frequency Variables (appear across many teams/projects)
+
+**If you maintain the role:**
+Edit `vars/dummy_variables.yml`:
+
+```yaml
+junit2_dummy_variables:
+  # Add variables that many teams encounter
+  common_variable: "PLACEHOLDER_COMMON_VARIABLE"
+  shared_info:
+    build_id: "PLACEHOLDER_BUILD_ID"
+```
+
+**If you don't maintain the role:**
+Request the role maintainer to add these variables to `vars/dummy_variables.yml`.
+
+### Low Frequency Variables (specific to your team/project)
+
+**If you maintain the playbook:**
+Add variables when calling the role:
+
+```yaml
+- name: Convert test reports
+  ansible.builtin.include_role:
+    name: junit2json
+  vars:
+    junit2_custom_dummy_variables:
+      # Add team-specific variables
+      pipeline_id: "PLACEHOLDER_PIPELINE_ID"
+      deployment:
+        environment: "PLACEHOLDER_ENVIRONMENT"
+```
+
+**If you don't maintain the playbook:**
+Create an external variables file `my_extras.yml`:
+
+```yaml
+junit2_custom_dummy_variables:
+  pipeline_id: "PLACEHOLDER_PIPELINE_ID"
+  deployment:
+    environment: "PLACEHOLDER_ENVIRONMENT"
+```
+
+Run with:
+
+```shell
+ansible-playbook my_playbook.yml -e @my_extras.yml
+```
+
+### Debug Mode
+
+Enable debug to see what variables are being set:
+
+```yaml
+junit2_dummy_debug: true
+```
+
+## Role Maintenance & Feedback
+
+**This role is maintained by:** GitHub team `@redhatci/verification`
+
+**Help us improve:** Please share your custom dummy variables with the maintenance team! When you add variables using `junit2_custom_dummy_variables` or external files, let `@redhatci/verification` know what variables you needed. This helps us identify high-frequency variables that should be moved into the role for everyone's benefit.
+
+## Variables Already Handled
+
+These patterns are already handled (may change based on test data encountered):
+
+- `{{ expectation_failed }}`
+- `{{ job_info.job.id }}`
+- `{{ ci_job_id }}`
+- `{{ error_message }}`
+- `{{ timestamp }}`

--- a/playbooks/infra/reporting/roles/junit2json/filter_plugins/junit2obj.py
+++ b/playbooks/infra/reporting/roles/junit2json/filter_plugins/junit2obj.py
@@ -1,0 +1,455 @@
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+import xml.etree.ElementTree as etree
+
+__metaclass__ = type
+__version__ = "1.0.0"
+
+DOCUMENTATION = r"""
+---
+name: junit2obj
+version_added: "2.0.0"
+short_description: transform JUnit XML text data as dictionary retaining suites and cases structure to JSON text.
+description: >
+  This filter plugin transforms a string JUnit XML data to JSON
+  representation of it.
+  It is being implemented because 'junit2dict' filter does not
+  retain suites information (timings), hence not allowing collection of
+  running times as metrics for future analysis.
+positional: xml_report_text
+options:
+  xml_report_text:
+    description: The junit report xml text data
+    type: str
+    required: true
+"""
+
+
+EXAMPLES = r"""
+---
+- name: Convert JUnit report to a structured object
+  vars:
+    xml_report_text: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <testsuites tests="3" disabled="2" errors="0" failures="0" time="0.000426228">
+          <testsuite name="Performance Addon Operator Reboot" package="/home/jenkins/workspace/CNF/cnf-compute-4.18"
+              tests="3" disabled="0" skipped="2" errors="0" failures="0" time="0.000426228" timestamp="2024-12-12T20:12:23">
+              <properties>
+                  <property name="SuiteSucceeded" value="true"></property>
+                  <property name="SuiteHasProgrammaticFocus" value="false"></property>
+                  <property name="SpecialSuiteFailureReason" value=""></property>
+                  <property name="SuiteLabels" value="[]"></property>
+                  <property name="RandomSeed" value="1734025939"></property>
+                  <property name="RandomizeAllSpecs" value="false"></property>
+                  <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)"></property>
+              </properties>
+              <testcase name="[It] [disruptive][node][kubelet][devicemanager] Device management tests"
+                  classname="Performance Addon Operator Reboot" status="skipped" time="0">
+                  <skipped message="skipped"></skipped>
+              </testcase>
+              <testcase name="[It] [disruptive][node][kubelet][devicemanager] Device management tests [tier-3]"
+                  classname="Performance Addon Operator Reboot" status="skipped" time="0">
+                  <skipped message="skipped"></skipped>
+              </testcase>
+              <testcase name="[ReportAfterSuite] e2e serial suite"
+                  classname="Performance Addon Operator Reboot" status="passed" time="6.826e-05">
+                  <system-err>&gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;</system-err>
+              </testcase>
+          </testsuite>
+      </testsuites>
+  ansible.builtin.debug:
+    msg: "{{ xml_report_text | junit2obj }}"
+# =>
+# {
+#     "time": 0.000426228,
+#     "tests": 3,
+#     "failures": 0,
+#     "errors": 0,
+#     "skipped": 2,
+#     "test_suites": [
+#         {
+#             "name": "Performance Addon Operator Reboot",
+#             "time": 0.0,
+#             "timestamp": "2024-12-12T20:12:23",
+#             "tests": 3,
+#             "failures": 0,
+#             "errors": 0,
+#             "skipped": 2,
+#             "properties": {
+#                 "SuiteSucceeded": "true",
+#                 "SuiteHasProgrammaticFocus": "false",
+#                 "SpecialSuiteFailureReason": "",
+#                 "SuiteLabels": "[]",
+#                 "RandomSeed": "1734025939",
+#                 "RandomizeAllSpecs": "false",
+#                 "LabelFilter": "(!openshift && tier-0)"
+#             },
+#             "test_cases": [
+#                 {
+#                     "name": "[It] [disruptive][node][kubelet][devicemanager] Device management tests",
+#                     "classname": "Performance Addon Operator Reboot",
+#                     "time": 0.0,
+#                     "result": [
+#                         {
+#                             "message": "skipped",
+#                             "status": "skipped"
+#                         }
+#                     ]
+#                 },
+#                 {
+#                     "name": "[It] [disruptive][node][kubelet][devicemanager] Device management tests [tier-3]",
+#                     "classname": "Performance Addon Operator Reboot",
+#                     "time": 0.0,
+#                     "result": [
+#                         {
+#                             "message": "skipped",
+#                             "status": "skipped"
+#                         }
+#                     ]
+#                 },
+#                 {
+#                     "name": "[ReportAfterSuite] e2e serial suite",
+#                     "classname": "Performance Addon Operator Reboot",
+#                     "time": 6.826e-05,
+#                     "result": [
+#                         {
+#                             "message": "passed",
+#                             "status": "passed"
+#                         }
+#                     ],
+#                     "system_err": "> &gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;"
+#                 }
+#             ]
+#         }
+#     ]
+# }
+"""
+
+
+RETURN = r"""
+---
+_value:
+  description:
+    - JSON data
+  type: dict
+"""
+
+def _safe_int(value: Optional[str], default: int = 0) -> int:
+    """Safely convert string to int with default fallback.
+
+    Args:
+        value: String value to convert
+        default: Default value if conversion fails
+
+    Returns:
+        Converted integer or default value
+    """
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_float(value: Optional[str], default: float = 0.0) -> float:
+    """Safely convert string to float with default fallback.
+
+    Args:
+        value: String value to convert
+        default: Default value if conversion fails
+
+    Returns:
+        Converted float or default value
+    """
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_str(value: Optional[str], default: str = "") -> float:
+    """Safely convert string to float with default fallback.
+
+    Args:
+        value: String value to convert
+        default: Default value if conversion fails
+
+    Returns:
+        Converted float or default value
+    """
+    if value is None:
+        return default
+    try:
+        return str(value)
+    except (ValueError, TypeError):
+        return default
+
+ATTR2CONVERSION = {
+    "name": (_safe_str, ""),
+    "timestamp": (_safe_str, time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(0))),
+    "time": (_safe_float, 0.0),
+    "tests": (_safe_int, 0),
+    "failures": (_safe_int, 0),
+    "errors": (_safe_int, 0),
+    "skipped": (_safe_int, 0),
+}
+
+def _collect_failure(testcase_elem: etree.Element) -> Optional[Dict[str, Any]]:
+    """Collect failure information from a test case element.
+
+    Args:
+        testcase_elem: XML element representing a test case
+
+    Returns:
+        Dictionary with failure information or None if no failure
+    """
+    failure_elem = testcase_elem.find("failure")
+    if failure_elem is None:
+        return None
+
+    result_dict = {
+        "message": failure_elem.get("message", "")
+    }
+
+    if failure_elem.text:
+        result_dict["text"] = failure_elem.text
+
+    # Preserve the raw JUnit type, but normalize the status
+    result_dict["failure_type"] = failure_elem.get("type", "")
+    result_dict["status"] = "failure"
+
+    return result_dict
+
+
+def _collect_error(testcase_elem: etree.Element) -> Optional[Dict[str, Any]]:
+    """Collect error information from a test case element.
+
+    Args:
+        testcase_elem: XML element representing a test case
+
+    Returns:
+        Dictionary with error information or None if no error
+    """
+    error_elem = testcase_elem.find("error")
+    if error_elem is None:
+        return None
+
+    result_dict = {
+        "message": error_elem.get("message", "")
+    }
+
+    if error_elem.text:
+        text = error_elem.text
+        result_dict["text"] = text
+        panic_indicators = ["[PANICKED]", "panic:", "PANIC"]
+        is_panic = any(indicator in text for indicator in panic_indicators)
+        # Check if this is actually a panicked test
+        result_dict["status"] = "panicked" if is_panic else "error"
+    else:
+        result_dict["status"] = "error"
+
+    return result_dict
+
+
+def _collect_skipped(testcase_elem: etree.Element) -> Optional[Dict[str, Any]]:
+    """Collect skipped information from a test case element.
+
+    Args:
+        testcase_elem: XML element representing a test case
+
+    Returns:
+        Dictionary with skipped information or None if not skipped
+    """
+    skipped_elem = testcase_elem.find("skipped")
+    if skipped_elem is None:
+        return None
+
+    result_dict = {
+        "message": skipped_elem.get("message", "skipped"),
+        "status": "skipped"
+    }
+
+    if skipped_elem.text:
+        result_dict["text"] = skipped_elem.text
+
+    return result_dict
+
+
+def _process_test_case(testcase_elem: etree.Element) -> Dict[str, Any]:
+    """Process test case element into a dictionary.
+
+    Args:
+        testcase_elem: XML element representing a test case
+
+    Returns:
+        Dictionary representation of the test case
+    """
+    curr_case: Dict[str, Any] = {
+        "name": testcase_elem.get("name", ""),
+        "classname": testcase_elem.get("classname", ""),
+        "time": _safe_float(testcase_elem.get("time")),
+    }
+
+    # Process test result elements (failure, error, skipped)
+    result_list = []
+
+    # Check for different result types in order of precedence
+    collector_handlers: Tuple[Callable[[etree.Element], Optional[Dict[str, Any]]], ...] = (
+        _collect_failure,
+        _collect_error,
+        _collect_skipped,
+    )
+
+    for handler in collector_handlers:
+        curr_elem = handler(testcase_elem)
+        if curr_elem is not None:
+            result_list.append(curr_elem)
+            break
+
+    # If no specific result, assume passed
+    if not result_list:
+        result_list.append({
+            "message": "passed",
+            "status": "passed",
+        })
+
+    curr_case["result"] = result_list
+
+    # Handle system-err and system-out
+    system_err = testcase_elem.find("system-err")
+    if system_err is not None and system_err.text:
+        curr_case["system_err"] = system_err.text
+
+    system_out = testcase_elem.find("system-out")
+    if system_out is not None and system_out.text:
+        curr_case["system_out"] = system_out.text
+
+    return curr_case
+
+
+def _process_test_suite(testsuite_elem: etree.Element) -> Dict[str, Any]:
+    """Process test suite element into a dictionary.
+
+    Args:
+        testsuite_elem: XML element representing a test suite
+
+    Returns:
+        Dictionary representation of the test suite
+    """
+    curr_suite = {}
+    for attr, (converter, _default) in ATTR2CONVERSION.items():
+        if attr in {"name", "timestamp", "time"}:
+            # Read name, timestamp, and time from XML (time includes setup/teardown)
+            curr_suite[attr] = converter(testsuite_elem.get(attr), default=_default)
+            continue
+        # Initialize counters to zero (will be calculated from test cases)
+        curr_suite[attr] = _default
+
+    # Process properties - always include properties section
+    properties_elem = testsuite_elem.find("properties")
+    properties = {}
+    if properties_elem is not None:
+        for prop_elem in properties_elem.findall("property"):
+            prop_name = prop_elem.get("name", "")
+            prop_value = prop_elem.get("value", "")
+            properties[prop_name] = prop_value
+    curr_suite["properties"] = properties
+
+    # Process test cases
+    test_cases = []
+    for testcase_elem in testsuite_elem.findall("testcase"):
+        test_case = _process_test_case(testcase_elem)
+        test_cases.append(test_case)
+        status = test_case.get("result", [{}])[0].get("status", "passed")
+        if status == "failure":
+            curr_suite["failures"] += 1
+        elif status in ("error", "panicked"):
+            curr_suite["errors"] += 1
+        elif status == "skipped":
+            curr_suite["skipped"] += 1
+        # Note: suite time is read from XML (includes setup/teardown), not calculated from test cases
+        curr_suite["tests"] += 1
+
+    curr_suite["test_cases"] = test_cases
+
+    return curr_suite
+
+
+class FilterModule:
+    """Filter module for converting JUnit XML reports to JSON."""
+
+    def filters(self) -> Dict[str, Any]:
+        """Return available filters.
+
+        Returns:
+            Dictionary mapping filter names to filter functions
+        """
+        return {
+            "junit2obj": self.junit2obj,
+        }
+
+    def junit2obj(self, junit_report_text: str) -> Dict[str, Any]:
+        """Convert JUnit XML Report into JSON using xml.etree.ElementTree.
+
+        Args:
+            junit_report_text: String containing JUnit XML report
+
+        Returns:
+            Dictionary representation of the JUnit report
+
+        Raises:
+            ValueError: If XML is invalid or has unexpected structure
+        """
+        if not isinstance(junit_report_text, str):
+            raise ValueError("Input must be a string")
+
+        if not junit_report_text.strip():
+            raise ValueError("Input XML cannot be empty")
+
+        # Parse XML
+        try:
+            root = etree.fromstring(junit_report_text.encode('utf-8'))
+        except etree.ParseError as exc:
+            raise ValueError(f"Invalid XML: {exc}") from exc
+
+        # Process test suites
+        test_suites = []
+        elements = root.findall("testsuite") if root.tag == "testsuites" else [root]
+        test_suites = [_process_test_suite(testsuite_elem) for testsuite_elem in elements]
+
+        # Build report structure
+        report = {
+            "test_suites": test_suites,
+            "schema_version": __version__,
+        }
+
+        # Use hybrid approach: prefer XML top-level values, fallback to calculated from suites
+        for attr in set(ATTR2CONVERSION.keys()) - {"name", "timestamp"}:
+            converter, _default = ATTR2CONVERSION[attr]
+            xml_value = root.get(attr)
+            if xml_value is None:
+                # Calculate from test suites if not in XML
+                report[attr] = sum(converter(suite.get(attr, None), default=_default) for suite in test_suites)
+                continue
+            # Use value from XML if available
+            report[attr] = converter(xml_value)
+
+        return report

--- a/playbooks/infra/reporting/roles/junit2json/filter_plugins/reportsmerger.py
+++ b/playbooks/infra/reporting/roles/junit2json/filter_plugins/reportsmerger.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python
+"""Ansible filter plugin that merges multiple json files into one
+
+The files should be the result of junit2obj conversion
+"""
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+from typing import Any
+from ansible.utils.display import Display
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+__version__ = "1.1.0"
+
+DOCUMENTATION = r"""
+---
+name: reportsmerger
+version_added: "1.1.0"
+short_description: merge multiple similarly built JSON files into one
+description: >
+  This filter plugin merges multiple test report JSON files (usually
+  converted by junit2obj filter) into a single consolidated test report.
+  It combines all test suites and recalculates aggregated statistics.
+positional: filenames
+options:
+  filenames:
+    description: List of filenames containing test report JSON data
+    type: list
+    elements: str
+    required: true
+  output_file:
+    description: Optional output file path to write merged data
+    type: str
+    required: false
+  strategy:
+    description: Optimization strategy for merging performance
+    type: str
+    required: false
+    default: normal
+    choices:
+      - normal
+      - large
+      - many
+      - shallow
+      - complex
+"""
+
+EXAMPLES = r"""
+---
+# Basic usage - merge multiple test report files
+- name: merge reports (default strategy)
+  ansible.builtin.set_fact:
+    merged: "{{ ['1.json', '2.json', '3.json'] | reportsmerger }}"
+
+# Use optimization strategies for different scenarios
+- name: merge large files with memory optimization
+  ansible.builtin.set_fact:
+    merged: "{{ large_files | reportsmerger(strategy='large') }}"
+
+- name: merge many files with parallel processing
+  ansible.builtin.set_fact:
+    merged: "{{ many_files | reportsmerger(strategy='many') }}"
+
+- name: get stats only with lazy test suites loading
+  ansible.builtin.set_fact:
+    stats: "{{ files | reportsmerger(strategy='shallow') }}"
+
+- name: merge complex files skipping heavy test case details
+  ansible.builtin.set_fact:
+    lightweight: "{{ complex_files | reportsmerger(strategy='complex') }}"
+
+# Write output directly to file
+- name: merge and save to file
+  ansible.builtin.set_fact:
+    output_path: "{{ files | reportsmerger(output_file='/tmp/merged.json') }}"
+"""
+
+RETURN = r"""
+---
+_value:
+  description:
+    - Merged test report data structure
+  type: dict
+  contains:
+    time:
+      description: Total time from all test suites
+      type: float
+    tests:
+      description: Total number of tests
+      type: int
+    failures:
+      description: Total number of failures
+      type: int
+    errors:
+      description: Total number of errors
+      type: int
+    skipped:
+      description: Total number of skipped tests
+      type: int
+    test_suites:
+      description: Combined list of all test suites from input files
+      type: list
+    schema_version:
+      description: Schema version
+      type: str
+"""
+
+
+class FilterModule:
+    """
+    Filter for merging multiple test report JSON files
+    """
+
+    def filters(self) -> dict[str, Any]:
+        """
+        filter boilerplate
+        """
+        return {
+            "reportsmerger": self.reportsmerger,
+        }
+
+    # pylint: disable=bad-whitespace
+    def reportsmerger(
+        self,
+        filenames: list[str],
+        strategy: str = "normal",
+        output_file: str | None = None,
+    ) -> dict[str, Any] | str:
+        """
+        Merge multiple test report JSON files into a single test report.
+
+        Args:
+            filenames: List of file paths containing test report JSON data
+            strategy: Optimization strategy to use:
+                     - "normal": Default behavior (backward compatible)
+                     - "large": Streaming aggregation for large files (low memory)
+                     - "many": Parallel processing for many files (faster I/O)
+                     - "shallow": Lazy test suites loading (stats-only focus)
+                     - "complex": Schema-specific parsing (skip heavy test_cases)
+            output_file: Optional output file path. If provided, writes merged
+                         data to file and returns the file path instead of
+                         the data
+
+        Returns:
+            dict: Merged report with aggregated statistics (if no output_file)
+            str: Output file path (if output_file provided)
+        """
+        import json
+        import os
+
+        display = Display()
+        if not isinstance(filenames, list):
+            raise TypeError("reportsmerger expects a list of filenames")
+        if not filenames:
+            raise ValueError("reportsmerger requires at least one filename")
+
+        strategy_chooser = {
+            "normal": self._strategy_normal,
+            "large": self._strategy_large_streaming,
+            "many": self._strategy_many_parallel,
+            "shallow": self._strategy_shallow_lazy,
+            "complex": self._strategy_complex_parsing,
+        }
+        # Validate output_file parameter
+        if output_file and not isinstance(output_file, str):
+            raise ValueError("output_file must be a string")
+        # Validate strategy parameter
+        if strategy not in strategy_chooser:
+            raise ValueError(f"Invalid strategy '{strategy}'. Must be one of: {list(strategy_chooser.keys())}")
+
+        # Strategy dispatch
+        strategy_handler = strategy_chooser[strategy]
+        merged_report = strategy_handler(filenames, display)
+
+        msg: str = "\n".join(
+            [
+                f"Merged {len(filenames)} files using '{strategy}' strategy:",
+                f"  tests:\t{merged_report['tests']}",
+                f"  failures:\t{merged_report['failures']}",
+                f"  errors:\t{merged_report['errors']}",
+                f"  skipped:\t{merged_report['skipped']}",
+                f"  time:\t{merged_report['time']}",
+                f"  test_suites:\t{len(merged_report['test_suites'])}",
+            ]
+        )
+        display.v(msg)
+
+        # NEW: If output file specified, write directly and return path
+        if output_file:
+            with open(output_file, "w", encoding="utf-8") as f:
+                json.dump(merged_report, f, indent=2)
+            display.v(f"Merged report written to {output_file}")
+            return output_file  # Return just the path, not the data
+
+        # Original behavior: return the data
+        return merged_report
+
+    def _load_and_validate_report(
+        self, filename: str, display: Display
+    ) -> dict[str, Any]:
+        """Load and validate a single report file."""
+        import json
+
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                report_data: dict[str, Any] = json.load(f)
+        except json.JSONDecodeError as jde:
+            msg = f"Invalid JSON in file {filename}: {jde}"
+            display.error(msg)
+            raise ValueError(msg) from jde
+        except Exception as exc:
+            msg = f"Error reading file {filename}: {exc}"
+            display.error(msg)
+            raise RuntimeError(msg) from exc
+
+        # Validate required fields
+        if "test_suites" not in report_data:
+            msg = f"Missing 'test_suites' field in {filename}"
+            display.error(msg)
+            raise ValueError(msg)
+
+        return report_data
+
+    def _accumulate_report_stats(
+        self,
+        report_data: dict[str, Any],
+        merged_report: dict[str, Any],
+        filename: str,
+        display: Display,
+    ) -> None:
+        """Accumulate statistics from a report into the merged report."""
+        # Update numeric statistics directly in merged_report
+        for field in ["time", "tests", "failures", "errors", "skipped"]:
+            value = report_data.get(field, 0.0 if field == "time" else 0)
+            if value is None:
+                # Handle None values by treating them as 0
+                value = 0.0 if field == "time" else 0
+            try:
+                if field == "time":
+                    merged_report[field] += float(value)
+                else:
+                    merged_report[field] += int(value)
+            except (ValueError, TypeError) as e:
+                msg = f"Invalid numeric data in {filename}: {e}"
+                display.error(msg)
+                raise ValueError(msg) from e
+
+        # Merge test suites
+        test_suites = report_data.get("test_suites", [])
+        if not isinstance(test_suites, list):
+            msg = f"Invalid 'test_suites' format in {filename}: expected list"
+            display.error(msg)
+            raise ValueError(msg)
+
+        merged_report["test_suites"].extend(test_suites)
+        msg = f"Successfully processed {filename}: {report_data.get('tests', 0)} tests"
+        display.vv(msg)
+
+    def _strategy_normal(self, filenames: list[str], display: Display) -> dict[str, Any]:
+        """Normal strategy - current behavior (backward compatible)"""
+        import os
+
+        merged_report: dict[str, Any] = {
+            "time": 0.0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "test_suites": [],
+            "schema_version": __version__,
+        }
+
+        for filename in filenames:
+            if not os.path.exists(filename):
+                msg = (
+                    f"reportsmerger plugin: file {filename} "
+                    "does not exist and was skipped"
+                )
+                display.warning(msg)
+                continue
+
+            report_data = self._load_and_validate_report(filename, display)
+            self._accumulate_report_stats(report_data, merged_report, filename, display)
+
+        return merged_report
+
+    def _strategy_large_streaming(self, filenames: list[str], display: Display) -> dict[str, Any]:
+        """Large files strategy - streaming aggregation for memory efficiency"""
+        import json
+        import os
+
+        merged_report: dict[str, Any] = {
+            "time": 0.0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "test_suites": [],
+            "schema_version": __version__,
+        }
+
+        for filename in filenames:
+            if not os.path.exists(filename):
+                msg = f"reportsmerger plugin: file {filename} does not exist and was skipped"
+                display.warning(msg)
+                continue
+
+            try:
+                # Stream processing - load, accumulate, discard immediately
+                with open(filename, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+
+                # Validate required fields
+                if "test_suites" not in data:
+                    raise ValueError(f"Missing 'test_suites' field in {filename}")
+
+                self._accumulate_report_stats(data, merged_report, filename, display)
+
+                # Explicit cleanup for memory efficiency
+                del data
+
+            except Exception as e:
+                msg = f"Error processing {filename}: {e}"
+                display.error(msg)
+                raise ValueError(msg) from e
+
+        return merged_report
+
+    def _strategy_many_parallel(self, filenames: list[str], display: Display) -> dict[str, Any]:
+        """Many files strategy - parallel processing for I/O efficiency"""
+        import json
+        import os
+        import threading
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        # Thread-safe merged report
+        stats_lock = threading.Lock()
+        merged_report: dict[str, Any] = {
+            "time": 0.0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "test_suites": [],
+            "schema_version": __version__,
+        }
+        processing_errors: list[str] = []
+
+        def process_single_file(filename: str) -> tuple[dict[str, Any] | None, str | None]:
+            """Process a single file and return data or error"""
+            if not os.path.exists(filename):
+                return None, f"File {filename} does not exist"
+
+            try:
+                return self._load_and_validate_report(filename, display), None
+            except Exception as e:
+                return None, str(e)
+
+        # Process files in parallel (max 4 threads for I/O bound work)
+        with ThreadPoolExecutor(max_workers=min(4, len(filenames))) as executor:
+            future_to_filename = {executor.submit(process_single_file, f): f for f in filenames}
+
+            for future in as_completed(future_to_filename):
+                filename = future_to_filename[future]
+                report_data, error = future.result()
+
+                if error:
+                    if "does not exist" in error:
+                        display.warning(f"reportsmerger plugin: {error} and was skipped")
+                    else:
+                        processing_errors.append(error)
+                    continue
+
+                # Thread-safe accumulation using the robust method
+                with stats_lock:
+                    self._accumulate_report_stats(report_data, merged_report, filename, display)
+
+        # Handle any processing errors
+        if processing_errors:
+            error_msg = "; ".join(processing_errors)
+            display.error(error_msg)
+            raise ValueError(error_msg)
+
+        return merged_report
+
+    def _strategy_shallow_lazy(self, filenames: list[str], display: Display) -> dict[str, Any]:
+        """Shallow strategy - lazy test suites loading for stats-focused operations"""
+        import json
+        import os
+
+        class LazyTestSuites:
+            """Lazy-loaded test suites that only merge when accessed"""
+            def __init__(self, file_list: list[str], display_obj: Display):
+                self._files = file_list
+                self._display = display_obj
+                self._merged_suites = None
+                self._length = None
+
+            def __iter__(self):
+                if self._merged_suites is None:
+                    self._load_all_suites()
+                # _merged_suites is guaranteed to be a list after _load_all_suites()
+                return iter(self._merged_suites or [])
+
+            def __len__(self):
+                if self._length is None:
+                    self._calculate_length()
+                return self._length
+
+            def _calculate_length(self):
+                """Calculate total number of test suites without loading them"""
+                total = 0
+                for filename in self._files:
+                    if not os.path.exists(filename):
+                        continue
+                    try:
+                        with open(filename, 'r', encoding='utf-8') as f:
+                            data = json.load(f)
+                            total += len(data.get("test_suites", []))
+                    except Exception:
+                        continue
+                self._length = total
+
+            def _load_all_suites(self):
+                """Load all test suites when actually needed"""
+                self._merged_suites = []
+                for filename in self._files:
+                    if not os.path.exists(filename):
+                        continue
+                    try:
+                        with open(filename, 'r', encoding='utf-8') as f:
+                            data = json.load(f)
+                            self._merged_suites.extend(data.get("test_suites", []))
+                    except Exception as e:
+                        self._display.warning(f"Error loading suites from {filename}: {e}")
+
+        # Fast stats-only accumulation
+        merged_stats = {"time": 0.0, "tests": 0, "failures": 0, "errors": 0, "skipped": 0}
+
+        for filename in filenames:
+            if not os.path.exists(filename):
+                msg = f"reportsmerger plugin: file {filename} does not exist and was skipped"
+                display.warning(msg)
+                continue
+
+            try:
+                with open(filename, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+
+                if "test_suites" not in data:
+                    raise ValueError(f"Missing 'test_suites' field in {filename}")
+
+                # Only accumulate top-level stats
+                merged_stats["time"] += float(data.get("time", 0.0))
+                merged_stats["tests"] += int(data.get("tests", 0))
+                merged_stats["failures"] += int(data.get("failures", 0))
+                merged_stats["errors"] += int(data.get("errors", 0))
+                merged_stats["skipped"] += int(data.get("skipped", 0))
+
+                display.vv(f"Stats from {filename}: {data.get('tests', 0)} tests")
+
+            except Exception as e:
+                msg = f"Error processing {filename}: {e}"
+                display.error(msg)
+                raise ValueError(msg) from e
+
+        return {
+            **merged_stats,
+            "test_suites": LazyTestSuites(filenames, display),
+            "schema_version": __version__,
+        }
+
+    def _strategy_complex_parsing(self, filenames: list[str], display: Display) -> dict[str, Any]:
+        """Complex strategy - schema-specific parsing to skip heavy test_cases"""
+        import json
+        import os
+
+        class TestSuiteOnlyDecoder(json.JSONDecoder):
+            """Custom decoder that strips heavy test_cases data during parsing"""
+            def decode(self, s):
+                obj = super().decode(s)
+                # Keep suite metadata but remove heavy test_cases details
+                if "test_suites" in obj:
+                    for suite in obj["test_suites"]:
+                        if "test_cases" in suite:
+                            # Keep count but remove detailed test case data
+                            test_cases_count = len(suite["test_cases"])
+                            suite["test_cases"] = []
+                            # Preserve the fact that there were test cases
+                            suite["_original_test_cases_count"] = test_cases_count
+                return obj
+
+        merged_report: dict[str, Any] = {
+            "time": 0.0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "test_suites": [],
+            "schema_version": __version__,
+        }
+
+        for filename in filenames:
+            if not os.path.exists(filename):
+                msg = f"reportsmerger plugin: file {filename} does not exist and was skipped"
+                display.warning(msg)
+                continue
+
+            try:
+                # Use custom decoder to avoid loading heavy test_cases
+                with open(filename, "r", encoding="utf-8") as f:
+                    data = json.load(f, cls=TestSuiteOnlyDecoder)
+
+                if "test_suites" not in data:
+                    raise ValueError(f"Missing 'test_suites' field in {filename}")
+
+                # Accumulate stats
+                merged_report["time"] += float(data.get("time", 0.0))
+                merged_report["tests"] += int(data.get("tests", 0))
+                merged_report["failures"] += int(data.get("failures", 0))
+                merged_report["errors"] += int(data.get("errors", 0))
+                merged_report["skipped"] += int(data.get("skipped", 0))
+
+                # Merge lightweight test suites
+                test_suites = data.get("test_suites", [])
+                merged_report["test_suites"].extend(test_suites)
+
+                display.vv(f"Parsed {filename} (lightweight): {data.get('tests', 0)} tests")
+
+            except Exception as e:
+                msg = f"Error processing {filename}: {e}"
+                display.error(msg)
+                raise ValueError(msg) from e
+
+        return merged_report

--- a/playbooks/infra/reporting/roles/junit2json/meta/argument_specs.yml
+++ b/playbooks/infra/reporting/roles/junit2json/meta/argument_specs.yml
@@ -1,0 +1,65 @@
+---
+# arguments spec file for junit2json role
+argument_specs:
+  main:
+    short_description: Main entry point for role junit2json
+    description: |
+      The resulting JSON file(s) are of the same structure for all the teams' and CI systems
+      and later used to be sent to the data collection system. This is the main entrypoint
+      for the role `junit2json`. Converts XMLs into JSON, if variable `junit2_do_merge` is `true`,
+      multiple XMLs are merged into one XML file.
+      Outputs:
+        - merged filename location is stored in the variable `junit2_output_merged_report`.
+        - variable `junit2_json_reports_list` contains list of all converted JSON file names
+      It is user's responsibility to consumer the right variable(s) in the next role(s).
+    author:
+      - Max Kovgan
+    options:
+      junit2_input_reports_list:
+        type: list
+        required: true
+        elements: str
+        description: |
+          List of JUnit XML report files to convert to JSON
+      junit2_do_merge:
+        type: bool
+        required: false
+        default: true
+        description: |
+          Should we merge data of converted reports into 1 file or not. When `false`, each report `XML` file
+          is converted to a corresponding json file appended `.json` extension.
+          Otherwise, resulting merged report is named as the directory, with `.report.json` extension.
+          In both cases, the result is stored under `junit2_output_dir`.
+      junit2_output_dir:
+        type: str
+        required: true
+        description: |
+          Output directory for resulting report JSON file path(s)
+      junit2_input_merged_report:
+        type: str
+        required: false
+        default: 'merged.junit.xml'
+        description: |
+          Relative file name for the Merged XML report (relevant only when `junit2_do_merge` is `true`),
+          it is generated under `junit2_output_dir`
+      junit2_output_merged_report:
+        type: str
+        required: false
+        default: 'merged.junit.json'
+        description: |
+          Relative file name for the JSON report (relevant only when `junit2_do_merge` is `true`),
+          it is generated under `junit2_output_dir`
+      junit2_json_reports_list:
+        type: list
+        required: false
+        default: []
+        elements: str
+        description: |
+          This is the output variable updated by the role for the converted JSON reports file names.
+          If it is defined outside of the role, the role updates it.
+      junit2_out_str:
+        type: bool
+        required: false
+        default: true
+        description: |
+          If true, the call to filter should pass object=true, otherwise object=false is passed.

--- a/playbooks/infra/reporting/roles/junit2json/meta/main.yml
+++ b/playbooks/infra/reporting/roles/junit2json/meta/main.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+galaxy_info:
+  author: Max Kovgan
+  description: Converts XML junit reports passed or in passed directory into single or fragmented JSON report file(s)
+  company: Red Hat, Inc.
+  issue_tracker_url: https://github.com/openshift-kni/eco-ci-cd/issues
+  license: Apache-2.0
+  min_ansible_version: "2.9"
+  galaxy_tags: []
+dependencies: []

--- a/playbooks/infra/reporting/roles/junit2json/tasks/convert.yml
+++ b/playbooks/infra/reporting/roles/junit2json/tasks/convert.yml
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# tasks file for junit2json
+# task list: convert.yml converts xml into JSON
+
+- name: Read file content
+  ansible.builtin.set_fact:
+    junit2json_xml_report_content: "{{ lookup('ansible.builtin.file', xml_report) }}"
+
+- name: Update junit2_result_data junit2_do_merge=true
+  ansible.builtin.set_fact:
+    junit2_result_data: "{{ junit2json_xml_report_content }}"
+
+- name: Setup JSON report file name
+  ansible.builtin.set_fact:
+    junit2_json_report_path: "{{ (xml_report | basename | regex_replace('\\.xml$', '.json')) if xml_report.endswith('.xml') else (xml_report | basename + '.json') }}"
+
+- name: Set junit2_output_report_path
+  ansible.builtin.set_fact:
+    junit2_output_report_path: "{{ junit2_output_dir }}/{{ junit2_json_report_path }}"
+
+- name: Update output variable junit2_json_reports_list
+  ansible.builtin.set_fact:
+    junit2_json_reports_list: "{{ junit2_json_reports_list + [junit2_output_report_path] }}"
+
+- name: Ensure junit2_output_dir is created
+  ansible.builtin.include_tasks:
+    file: ensure-dir.yml
+  vars:
+    folder_path: "{{ junit2_output_dir }}"
+
+- name: Write data as JSON object to file
+  ansible.builtin.copy:
+    content: "{{ junit2_result_data | junit2obj | to_nice_json(indent=2) }}"
+    dest: "{{ junit2_output_report_path }}"
+    mode: "0644"
+  when: not junit2_out_str | bool
+
+- name: Write data as JSON string to file
+  ansible.builtin.copy:
+    content: "{{ junit2_result_data | junit2obj }}"
+    dest: "{{ junit2_output_report_path }}"
+    mode: "0644"
+  when: junit2_out_str | bool

--- a/playbooks/infra/reporting/roles/junit2json/tasks/ensure-dir.yml
+++ b/playbooks/infra/reporting/roles/junit2json/tasks/ensure-dir.yml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# tasks file ensure-dir.yml for role junit2json
+# Ensures folder_path exists
+
+- name: Collect folder_path stat
+  ansible.builtin.stat:
+    path: "{{ folder_path }}"
+  register: _ensure_dir_stat
+
+- name: Ensure missing folder_path is created
+  ansible.builtin.file:
+    path: "{{ folder_path }}"
+    state: directory
+    mode: "0750"
+  when:
+    - not(_ensure_dir_stat.stat.isdir | default(false))

--- a/playbooks/infra/reporting/roles/junit2json/tasks/expand.yml
+++ b/playbooks/infra/reporting/roles/junit2json/tasks/expand.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# tasks file for role `junit2json`
+
+- name: Print xml_report value
+  ansible.builtin.debug:
+    var: xml_report
+    verbosity: 2
+
+- name: Collect xml_report stat
+  ansible.builtin.stat:
+    path: "{{ xml_report }}"
+  register: _xml_report_stat
+
+- name: Verify xml_report exists and is a regular file
+  ansible.builtin.assert:
+    that:
+      - not(_xml_report_stat.stat.isdir)
+      - _xml_report_stat.stat.exists
+    fail_msg: |
+      Verification failed. REASON: The file "{{ xml_report }}" must be an existing regular file.
+
+- name: Update junit2_reports_list with a JUnit XML report item
+  ansible.builtin.set_fact:
+    junit2_reports_list: "{{ junit2_reports_list + [xml_report] }}"
+  when:
+    - _xml_report_stat.stat.exists

--- a/playbooks/infra/reporting/roles/junit2json/tasks/main.yml
+++ b/playbooks/infra/reporting/roles/junit2json/tasks/main.yml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# tasks file main.yml for role junit2json
+
+# NOTE: in case somebody did not install the collection properly, we test for filter's dependency
+
+- name: Validate role variables
+  ansible.builtin.assert:
+    that:
+      - junit2_input_reports_list | length > 0
+      - junit2_output_dir | length > 0
+    fail_msg: "One of the mandatory variables is missing or empty"
+
+# During repeating tests, this variable needs to be reset each run
+- name: Initialize reports variable
+  ansible.builtin.set_fact:
+    junit2_reports_list: []
+
+- name: Print input reports variable
+  ansible.builtin.debug:
+    var: junit2_input_reports_list
+    verbosity: 2
+
+- name: Expand the input list to list of existing files
+  ansible.builtin.include_tasks:
+    file: expand.yml
+  loop: "{{ junit2_input_reports_list }}"
+  loop_control:
+    loop_var: xml_report
+
+- name: Convert XML to JSON
+  ansible.builtin.include_tasks:
+    file: "convert.yml"
+  loop: "{{ junit2_reports_list }}"
+  loop_control:
+    loop_var: xml_report
+  when:
+    - junit2_reports_list | length > 0
+
+- name: Merge JUnit XML reports into one file junit2_do_merge=true
+  ansible.builtin.include_tasks:
+    file: merge.yml
+  when:
+    - junit2_do_merge
+    - junit2_json_reports_list | length > 0

--- a/playbooks/infra/reporting/roles/junit2json/tasks/merge.yml
+++ b/playbooks/infra/reporting/roles/junit2json/tasks/merge.yml
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# tasks file merge.yml for role junit2json
+# merges multiple XMLs into 1 and converts it into JSON
+
+# Refer to this role [doc/dummy_variables.md](doc/dummy_variables.md) for more details
+# Load and set dummy variables to prevent template evaluation errors in test data
+- name: Load dummy variables configuration
+  ansible.builtin.include_vars:
+    file: dummy_variables.yml
+
+- name: Merge custom dummy variables with defaults
+  ansible.builtin.set_fact:
+    junit2_dummy_variables: "{{ junit2_dummy_variables | combine(junit2_custom_dummy_variables, recursive=True) }}"
+  when:
+    - junit2_custom_dummy_variables | length > 0
+    - junit2_dummy_variables | default({}) | length > 0
+
+- name: Debug dummy variables being set
+  ansible.builtin.debug:
+    var: junit2_dummy_variables
+    verbosity: 2
+  when:
+    - junit2_dummy_debug | bool
+    - junit2_dummy_variables | default({}) | length > 0
+
+- name: Set dummy variables for template strings in test data
+  ansible.builtin.set_fact:
+    "{{ item.key }}": "{{ item.value }}" # noqa redhat-ci[no-role-prefix]
+  loop: "{{ junit2_dummy_variables | default({}) | dict2items }}"
+  when:
+    - vars[item.key] is not defined
+    - junit2_dummy_variables | default({}) | length > 0
+
+- name: Ensure junit2_output_dir is created
+  ansible.builtin.include_tasks:
+    file: ensure-dir.yml
+  loop:
+    - "{{ junit2_output_dir }}"
+  loop_control:
+    loop_var: folder_path
+
+- name: Merge multiple JSON report files into single consolidated report
+  ansible.builtin.set_fact:
+    junit2_result_merged_file: "{{ junit2_output_dir }}/{{ junit2_output_merged_report }}"
+
+- name: Merge multiple JSON report files into single consolidated report
+  ansible.builtin.set_fact:
+    junit2_result_merged_data: "{{ junit2_json_reports_list | reportsmerger(strategy='normal') }}"
+
+- name: Write merged data to file
+  ansible.builtin.copy:
+    content: "{{ junit2_result_merged_data | to_nice_json(indent=2) }}"
+    dest: "{{ junit2_result_merged_file }}"
+    mode: "0644"
+
+- name: Debug merged data
+  ansible.builtin.debug:
+    var: junit2_result_merged_data
+    verbosity: 2
+
+- name: Debug merged file path
+  ansible.builtin.debug:
+    var: junit2_result_merged_file
+    verbosity: 2

--- a/playbooks/infra/reporting/roles/junit2json/tests/test.yml
+++ b/playbooks/infra/reporting/roles/junit2json/tests/test.yml
@@ -1,0 +1,110 @@
+---
+- name: Test junit2json role - simple input
+  hosts: localhost
+  connection: local
+  vars:
+    junit2_output_merged_report: "merged.junit.json"
+  tasks:
+    - name: Run tests for both values of junit2_out_str
+      block:
+        - name: Test role junit2json without merge junit2_out_str=true
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ playbook_dir }}/unit/data/test_junit2obj_simple_input.xml"
+            junit2_output_dir: "{{ playbook_dir }}/"
+            junit2_do_merge: false
+            junit2_out_str: true
+
+        - name: Load actual result into variable actual junit2_out_str=true
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', junit2_output_report_path) }}"
+
+        - name: Load expected result into variable expected junit2_out_str=true
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', playbook_dir + '/unit/data/test_junit2obj_simple_result.json') }}"
+
+        - name: Ensure 1 simple test passes junit2_out_str=true
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+        - name: Reset global variable junit2_out_str=true
+          ansible.builtin.set_fact:
+            junit2_json_reports_list: []
+
+        - name: Test role junit2json with merge junit2_out_str=true
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ playbook_dir }}/unit/data/test_junit2obj_simple_input.xml"
+              - "{{ playbook_dir }}/unit/data/test_junit2obj_failure_input.xml"
+            junit2_output_dir: "{{ playbook_dir }}"
+            junit2_do_merge: true
+            junit2_out_str: true
+
+        - name: Load actual result into variable actual junit2_out_str=true
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', junit2_result_merged_file) }}"
+
+        - name: Load expected result into variable expected junit2_out_str=true
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', playbook_dir + '/unit/data/' + junit2_output_merged_report) | from_json }}"
+
+        - name: Ensure 2 merged test passes junit2_out_str=true
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+        - name: Test role junit2json without merge junit2_out_str=false
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ playbook_dir }}/unit/data/test_junit2obj_simple_input.xml"
+            junit2_output_dir: "{{ playbook_dir }}/"
+            junit2_do_merge: false
+            junit2_out_str: false
+
+        - name: Load actual result into variable actual junit2_out_str=false
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', junit2_output_report_path) | from_json }}"
+
+        - name: Load expected result into variable expected junit2_out_str=false
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', playbook_dir + '/unit/data/test_junit2obj_simple_result.json') | from_json }}"
+
+        - name: Ensure 3 simple test passes junit2_out_str=false
+          ansible.builtin.assert:
+            that:
+              - actual == expected
+
+        - name: Reset global variable junit2_out_str=false
+          ansible.builtin.set_fact:
+            junit2_json_reports_list: []
+
+        - name: Test role junit2json with merge junit2_out_str=false
+          ansible.builtin.include_role:
+            name: junit2json
+          vars:
+            junit2_input_reports_list:
+              - "{{ playbook_dir }}/unit/data/test_junit2obj_simple_input.xml"
+              - "{{ playbook_dir }}/unit/data/test_junit2obj_failure_input.xml"
+            junit2_output_dir: "{{ playbook_dir }}/"
+            junit2_do_merge: true
+            junit2_out_str: false
+
+        - name: Load actual result into variable actual junit2_out_str=false
+          ansible.builtin.set_fact:
+            actual: "{{ lookup('file', junit2_result_merged_file) | from_json }}"
+
+        - name: Load expected result into variable expected junit2_out_str=false
+          ansible.builtin.set_fact:
+            expected: "{{ lookup('file', playbook_dir + '/unit/data/' + (junit2_result_merged_file | basename)) }}"
+
+        - name: Ensure 4 merged test passes junit2_out_str=false
+          ansible.builtin.assert:
+            that:
+              - actual == expected

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/merged.junit.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/merged.junit.json
@@ -1,0 +1,113 @@
+{
+    "time": 0.044454510165527344,
+    "tests": 5,
+    "failures": 2,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Performance Addon Operator Reboot",
+            "time": 0.000426228,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 3,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "true",
+                "SuiteHasProgrammaticFocus": "false",
+                "SpecialSuiteFailureReason": "",
+                "SuiteLabels": "[]",
+                "RandomSeed": "1734025939",
+                "RandomizeAllSpecs": "false",
+                "LabelFilter": "(!openshift && tier-0)",
+                "FocusStrings": "",
+                "SkipStrings": "",
+                "FocusFiles": "",
+                "SkipFiles": "",
+                "FailOnPending": "false",
+                "FailOnEmpty": "false",
+                "FailFast": "false",
+                "FlakeAttempts": "2",
+                "DryRun": "false",
+                "ParallelTotal": "1",
+                "OutputInterceptorMode": ""
+            },
+            "test_cases": [
+                {
+                    "name": "[It] [disruptive][node][kubelet][devicemanager]",
+                    "classname": "Performance Addon Operator Reboot",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Device management tests Verify that pods requesting devices",
+                    "classname": "Performance Addon Operator Reboot",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "[ReportAfterSuite] e2e serial suite",
+                    "classname": "Performance Addon Operator Reboot",
+                    "time": 6.826e-05,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ],
+                    "system_err": "> Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;"
+                }
+            ]
+        },
+        {
+            "name": "dci-openshift-app-agent",
+            "time": 0.044028282165527344,
+            "timestamp": "1970-01-01T00:00:00",
+            "tests": 2,
+            "failures": 2,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "[jumphost] Check test results step: redhatci.ocp.verify_tests : Fail if not all test results are as expected for cu_op_deploy_cloudran_site_new_version.xml msg=The following expectations failed: PLACEHOLDER_EXPECTATION_FAILED",
+                    "classname": "/usr/share/ansible/collections/ansible_collections/redhatci/ocp/roles/verify_tests/tasks/parse_junit_file.yml:19",
+                    "time": 0.026203,
+                    "result": [
+                        {
+                            "failure_type": "failure",
+                            "message": "The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]",
+                            "text": "{\n\"changed\": false,\n\"msg\": \"The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]\"\n}",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "[jumphost] Check test results step: Fail properly msg=Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/PLACEHOLDER_JOB_ID/jobStates",
+                    "classname": "/usr/share/dci-openshift-app-agent/dci-openshift-app-agent.yml:271",
+                    "time": 0.017825,
+                    "result": [
+                        {
+                            "failure_type": "failure",
+                            "message": "Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates",
+                            "text": "{\n\"changed\": false,\n\"msg\": \"Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates\"\n}",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.1.0"
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_complex_input.xml
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_complex_input.xml
@@ -1,0 +1,190 @@
+<?xml version='1.0' encoding='utf-8'?>
+<testsuites tests="3" failures="1" errors="1" skipped="1" time="373258.204">
+    <testsuite name="PAO Hypershift tests" package="/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/12_hypershift" tests="1" disabled="0" skipped="1" errors="0" failures="0" time="0.0" timestamp="2024-12-11T19:58:52">
+        <properties>
+            <property name="SuiteSucceeded" value="true" />
+            <property name="SuiteHasProgrammaticFocus" value="false" />
+            <property name="SpecialSuiteFailureReason" value="" />
+            <property name="SuiteLabels" value="[]" />
+            <property name="RandomSeed" value="1733939893" />
+            <property name="RandomizeAllSpecs" value="false" />
+            <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)" />
+        </properties>
+        <testcase name="[It] Multiple performance profile in hypershift Multiple Nodepool [test_id:75077] should verify support for different performance profiles on hosted cluster via multiple node pools [Hypershift]" classname="PAO Hypershift tests" status="skipped" time="0">
+            <skipped message="skipped" />
+        </testcase>
+    </testsuite>
+    <testsuite name="PPC Suite" package="/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc" tests="1" disabled="0" skipped="0" errors="1" failures="0" time="22.8" timestamp="2024-12-11T19:58:30">
+        <properties>
+            <property name="SuiteSucceeded" value="false" />
+            <property name="SuiteHasProgrammaticFocus" value="false" />
+            <property name="SpecialSuiteFailureReason" value="" />
+            <property name="SuiteLabels" value="[]" />
+            <property name="RandomSeed" value="1733939893" />
+            <property name="RandomizeAllSpecs" value="false" />
+            <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)" />
+        </properties>
+        <testcase name="[It] [rfe_id: 38968] PerformanceProfile setup helper and platform awareness PPC Sanity Tests [test_id:40940] Performance Profile regression tests [performance-profile-creator, tier-0]" classname="PPC Suite" status="panicked" time="18.544246352000002">
+            <error message="runtime error: invalid memory address or nil pointer dereference" type="panicked">[PANICKED] Test Panicked
+In [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 12/11/24 19:58:48.558
+
+runtime error: invalid memory address or nil pointer dereference
+
+Full Stack Trace
+  github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc.init.func1.1.1()
+  	/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:96 +0x60c
+
+There were additional failures detected after the initial failure. These are visible in the timeline
+</error>
+            <system-err>&gt; Enter [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:30.014
+Trying to pull quay.io/openshift/origin-cluster-node-tuning-operator:latest...
+Getting image source signatures
+Copying blob sha256:0e20fa233dde7061291aaf1a0930d6db144a6347b30ca30d78bbad6dddc71ccd
+Copying blob sha256:709b1b990394fe27604cb928d916cc53350ffb270922f4d155620cbd65754626
+Copying blob sha256:9530663780b1f345858f87937f797465f424dfb8c714837b1dfaedfd045d1705
+Copying blob sha256:3e9004538d305bc491dcb2da7111d4caa4ecc295110cf5667d9f9b482a9647fd
+Copying config sha256:5de7e560ae2a5d2690d9c9fa642953e369d1990f5a65418fd649554921bc18ef
+Writing manifest to image destination
+level=info msg="Nodes names targeted by worker pool are: "
+Error: targeted nodes differ: no suitable nodes to compare
+Usage:
+  performance-profile-creator [flags]
+  performance-profile-creator [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  info        requires --must-gather-dir-path, ignores other arguments. [Valid values: log,json]
+
+Flags:
+      --disable-ht                        Disable Hyperthreading
+      --enable-hardware-tuning            Enable setting maximum cpu frequencies
+  -h, --help                              help for performance-profile-creator
+      --mcp-name string                   MCP name corresponding to the target machines (required)
+      --must-gather-dir-path string       Must gather directory path (default "must-gather")
+      --node-pool-name string             Node pool name corresponding to the target machines (HyperShift only)
+      --offlined-cpu-count int            Number of offlined CPUs
+      --per-pod-power-management          Enable Per Pod Power Management
+      --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
+      --profile-name string               Name of the performance profile to be created (default "performance")
+      --reserved-cpu-count int            Number of reserved CPUs (required)
+      --rt-kernel                         Enable Real Time Kernel (required)
+      --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes
+      --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
+      --user-level-networking             Run with User level Networking(DPDK) enabled
+
+Use "performance-profile-creator [command] --help" for more information about a command.
+
+[PANICKED] Failure recorded during attempt 1:
+Test Panicked
+In [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 12/11/24 19:58:46.745
+
+runtime error: invalid memory address or nil pointer dereference
+
+Full Stack Trace
+  github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc.init.func1.1.1()
+  	/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:96 +0x60c
+&lt; Exit [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:46.745 (16.731s)
+
+Attempt #1 Failed.  Retrying ↺ @ 12/11/24 19:58:46.745
+
+&gt; Enter [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:46.745
+level=info msg="Nodes names targeted by worker pool are: "
+Error: targeted nodes differ: no suitable nodes to compare
+Usage:
+  performance-profile-creator [flags]
+  performance-profile-creator [command]
+
+Available Commands:
+  completion  Generate the autocompletion script for the specified shell
+  help        Help about any command
+  info        requires --must-gather-dir-path, ignores other arguments. [Valid values: log,json]
+
+Flags:
+      --disable-ht                        Disable Hyperthreading
+      --enable-hardware-tuning            Enable setting maximum cpu frequencies
+  -h, --help                              help for performance-profile-creator
+      --mcp-name string                   MCP name corresponding to the target machines (required)
+      --must-gather-dir-path string       Must gather directory path (default "must-gather")
+      --node-pool-name string             Node pool name corresponding to the target machines (HyperShift only)
+      --offlined-cpu-count int            Number of offlined CPUs
+      --per-pod-power-management          Enable Per Pod Power Management
+      --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
+      --profile-name string               Name of the performance profile to be created (default "performance")
+      --reserved-cpu-count int            Number of reserved CPUs (required)
+      --rt-kernel                         Enable Real Time Kernel (required)
+      --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes
+      --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default "restricted")
+      --user-level-networking             Run with User level Networking(DPDK) enabled
+
+Use "performance-profile-creator [command] --help" for more information about a command.
+
+[PANICKED] Test Panicked
+In [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 12/11/24 19:58:48.558
+
+runtime error: invalid memory address or nil pointer dereference
+
+Full Stack Trace
+  github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc.init.func1.1.1()
+  	/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:96 +0x60c
+&lt; Exit [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:48.558 (1.813s)
+</system-err>
+        </testcase>
+    </testsuite>
+    <testsuite name="Performance Test" package="/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance" tests="1" disabled="0" skipped="0" errors="0" failures="1" time="1363.306" timestamp="2024-12-09T13:43:44">
+        <properties>
+            <property name="SuiteSucceeded" value="false" />
+            <property name="SuiteHasProgrammaticFocus" value="false" />
+            <property name="SpecialSuiteFailureReason" value="" />
+            <property name="SuiteLabels" value="[]" />
+            <property name="RandomSeed" value="1733769817" />
+            <property name="RandomizeAllSpecs" value="false" />
+            <property name="LabelFilter" value="" />
+        </properties>
+        <testcase name="[It] [ref_id: 40307][pao]Resizing Network Queues Updating performance profile for netqueues [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match [tier-1]" classname="Performance Test" status="failed" time="11.996012308">
+            <failure message="Expected&#10;    &lt;int&gt;: 4&#10;not to equal&#10;    &lt;int&gt;: 4" type="failed">[FAILED] Expected
+    &lt;int&gt;: 4
+not to equal
+    &lt;int&gt;: 4
+In [It] at: /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:269 @ 12/09/24 13:47:56.989
+
+There were additional failures detected after the initial failure. These are visible in the timeline
+</failure>
+            <system-err>&gt; Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:45.016
+&lt; Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:45.016 (0s)
+&gt; Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:45.016
+&lt; Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:45.023 (7ms)
+&gt; Enter [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:45.023
+STEP: Enable UserLevelNetworking and add Devices in Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:232 @ 12/09/24 13:47:45.438
+[FAILED] Failure recorded during attempt 1:
+Expected
+    &lt;int&gt;: 4
+not to equal
+    &lt;int&gt;: 4
+In [It] at: /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:269 @ 12/09/24 13:47:51.011
+&lt; Exit [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:51.012 (5.988s)
+&gt; Enter [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:51.012
+STEP: Reverting the Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:90 @ 12/09/24 13:47:51.012
+&lt; Exit [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:51.041 (29ms)
+
+Attempt #1 Failed.  Retrying ↺ @ 12/09/24 13:47:51.041
+
+&gt; Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:51.041
+&lt; Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:51.041 (0s)
+&gt; Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:51.041
+&lt; Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:51.047 (6ms)
+&gt; Enter [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:51.047
+STEP: Enable UserLevelNetworking and add Devices in Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:232 @ 12/09/24 13:47:51.43
+[FAILED] Expected
+    &lt;int&gt;: 4
+not to equal
+    &lt;int&gt;: 4
+In [It] at: /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:269 @ 12/09/24 13:47:56.989
+&lt; Exit [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:56.989 (5.942s)
+&gt; Enter [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:56.989
+STEP: Reverting the Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:90 @ 12/09/24 13:47:56.989
+&lt; Exit [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:57.012 (23ms)
+</system-err>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_complex_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_complex_result.json
@@ -1,0 +1,108 @@
+{
+    "time": 373258.204,
+    "tests": 3,
+    "failures": 1,
+    "errors": 1,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "PAO Hypershift tests",
+            "time": 0.0,
+            "timestamp": "2024-12-11T19:58:52",
+            "tests": 1,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "true",
+                "SuiteHasProgrammaticFocus": "false",
+                "SpecialSuiteFailureReason": "",
+                "SuiteLabels": "[]",
+                "RandomSeed": "1733939893",
+                "RandomizeAllSpecs": "false",
+                "LabelFilter": "(!openshift && tier-0)"
+            },
+            "test_cases": [
+                {
+                    "name": "[It] Multiple performance profile in hypershift Multiple Nodepool [test_id:75077] should verify support for different performance profiles on hosted cluster via multiple node pools [Hypershift]",
+                    "classname": "PAO Hypershift tests",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "PPC Suite",
+            "time": 22.8,
+            "timestamp": "2024-12-11T19:58:30",
+            "tests": 1,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 0,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "SuiteHasProgrammaticFocus": "false",
+                "SpecialSuiteFailureReason": "",
+                "SuiteLabels": "[]",
+                "RandomSeed": "1733939893",
+                "RandomizeAllSpecs": "false",
+                "LabelFilter": "(!openshift && tier-0)"
+            },
+            "test_cases": [
+                {
+                    "name": "[It] [rfe_id: 38968] PerformanceProfile setup helper and platform awareness PPC Sanity Tests [test_id:40940] Performance Profile regression tests [performance-profile-creator, tier-0]",
+                    "classname": "PPC Suite",
+                    "time": 18.544246352000002,
+                    "result": [
+                        {
+                            "message": "runtime error: invalid memory address or nil pointer dereference",
+                            "text": "[PANICKED] Test Panicked\nIn [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 12/11/24 19:58:48.558\n\nruntime error: invalid memory address or nil pointer dereference\n\nFull Stack Trace\n  github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc.init.func1.1.1()\n  \t/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:96 +0x60c\n\nThere were additional failures detected after the initial failure. These are visible in the timeline\n",
+                            "status": "panicked"
+                        }
+                    ],
+                    "system_err": "> Enter [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:30.014\nTrying to pull quay.io/openshift/origin-cluster-node-tuning-operator:latest...\nGetting image source signatures\nCopying blob sha256:0e20fa233dde7061291aaf1a0930d6db144a6347b30ca30d78bbad6dddc71ccd\nCopying blob sha256:709b1b990394fe27604cb928d916cc53350ffb270922f4d155620cbd65754626\nCopying blob sha256:9530663780b1f345858f87937f797465f424dfb8c714837b1dfaedfd045d1705\nCopying blob sha256:3e9004538d305bc491dcb2da7111d4caa4ecc295110cf5667d9f9b482a9647fd\nCopying config sha256:5de7e560ae2a5d2690d9c9fa642953e369d1990f5a65418fd649554921bc18ef\nWriting manifest to image destination\nlevel=info msg=\"Nodes names targeted by worker pool are: \"\nError: targeted nodes differ: no suitable nodes to compare\nUsage:\n  performance-profile-creator [flags]\n  performance-profile-creator [command]\n\nAvailable Commands:\n  completion  Generate the autocompletion script for the specified shell\n  help        Help about any command\n  info        requires --must-gather-dir-path, ignores other arguments. [Valid values: log,json]\n\nFlags:\n      --disable-ht                        Disable Hyperthreading\n      --enable-hardware-tuning            Enable setting maximum cpu frequencies\n  -h, --help                              help for performance-profile-creator\n      --mcp-name string                   MCP name corresponding to the target machines (required)\n      --must-gather-dir-path string       Must gather directory path (default \"must-gather\")\n      --node-pool-name string             Node pool name corresponding to the target machines (HyperShift only)\n      --offlined-cpu-count int            Number of offlined CPUs\n      --per-pod-power-management          Enable Per Pod Power Management\n      --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default \"default\")\n      --profile-name string               Name of the performance profile to be created (default \"performance\")\n      --reserved-cpu-count int            Number of reserved CPUs (required)\n      --rt-kernel                         Enable Real Time Kernel (required)\n      --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes\n      --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default \"restricted\")\n      --user-level-networking             Run with User level Networking(DPDK) enabled\n\nUse \"performance-profile-creator [command] --help\" for more information about a command.\n\n[PANICKED] Failure recorded during attempt 1:\nTest Panicked\nIn [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 12/11/24 19:58:46.745\n\nruntime error: invalid memory address or nil pointer dereference\n\nFull Stack Trace\n  github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc.init.func1.1.1()\n  \t/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:96 +0x60c\n< Exit [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:46.745 (16.731s)\n\nAttempt #1 Failed.  Retrying \u21ba @ 12/11/24 19:58:46.745\n\n> Enter [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:46.745\nlevel=info msg=\"Nodes names targeted by worker pool are: \"\nError: targeted nodes differ: no suitable nodes to compare\nUsage:\n  performance-profile-creator [flags]\n  performance-profile-creator [command]\n\nAvailable Commands:\n  completion  Generate the autocompletion script for the specified shell\n  help        Help about any command\n  info        requires --must-gather-dir-path, ignores other arguments. [Valid values: log,json]\n\nFlags:\n      --disable-ht                        Disable Hyperthreading\n      --enable-hardware-tuning            Enable setting maximum cpu frequencies\n  -h, --help                              help for performance-profile-creator\n      --mcp-name string                   MCP name corresponding to the target machines (required)\n      --must-gather-dir-path string       Must gather directory path (default \"must-gather\")\n      --node-pool-name string             Node pool name corresponding to the target machines (HyperShift only)\n      --offlined-cpu-count int            Number of offlined CPUs\n      --per-pod-power-management          Enable Per Pod Power Management\n      --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default \"default\")\n      --profile-name string               Name of the performance profile to be created (default \"performance\")\n      --reserved-cpu-count int            Number of reserved CPUs (required)\n      --rt-kernel                         Enable Real Time Kernel (required)\n      --split-reserved-cpus-across-numa   Split the Reserved CPUs across NUMA nodes\n      --topology-manager-policy string    Kubelet Topology Manager Policy of the performance profile to be created. [Valid values: single-numa-node, best-effort, restricted] (default \"restricted\")\n      --user-level-networking             Run with User level Networking(DPDK) enabled\n\nUse \"performance-profile-creator [command] --help\" for more information about a command.\n\n[PANICKED] Test Panicked\nIn [It] at: /usr/lib/golang/src/runtime/panic.go:261 @ 12/11/24 19:58:48.558\n\nruntime error: invalid memory address or nil pointer dereference\n\nFull Stack Trace\n  github.com/openshift/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc.init.func1.1.1()\n  \t/home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:96 +0x60c\n< Exit [It] [test_id:40940] Performance Profile regression tests - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/10_performance_ppc/ppc.go:69 @ 12/11/24 19:58:48.558 (1.813s)\n"
+                }
+            ]
+        },
+        {
+            "name": "Performance Test",
+            "time": 1363.306,
+            "timestamp": "2024-12-09T13:43:44",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "SuiteHasProgrammaticFocus": "false",
+                "SpecialSuiteFailureReason": "",
+                "SuiteLabels": "[]",
+                "RandomSeed": "1733769817",
+                "RandomizeAllSpecs": "false",
+                "LabelFilter": ""
+            },
+            "test_cases": [
+                {
+                    "name": "[It] [ref_id: 40307][pao]Resizing Network Queues Updating performance profile for netqueues [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match [tier-1]",
+                    "classname": "Performance Test",
+                    "time": 11.996012308,
+                    "result": [
+                        {
+                            "failure_type": "failed",
+                            "message": "Expected\n    <int>: 4\nnot to equal\n    <int>: 4",
+                            "text": "[FAILED] Expected\n    <int>: 4\nnot to equal\n    <int>: 4\nIn [It] at: /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:269 @ 12/09/24 13:47:56.989\n\nThere were additional failures detected after the initial failure. These are visible in the timeline\n",
+                            "status": "failure"
+                        }
+                    ],
+                    "system_err": "> Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:45.016\n< Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:45.016 (0s)\n> Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:45.016\n< Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:45.023 (7ms)\n> Enter [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:45.023\nSTEP: Enable UserLevelNetworking and add Devices in Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:232 @ 12/09/24 13:47:45.438\n[FAILED] Failure recorded during attempt 1:\nExpected\n    <int>: 4\nnot to equal\n    <int>: 4\nIn [It] at: /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:269 @ 12/09/24 13:47:51.011\n< Exit [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:51.012 (5.988s)\n> Enter [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:51.012\nSTEP: Reverting the Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:90 @ 12/09/24 13:47:51.012\n< Exit [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:51.041 (29ms)\n\nAttempt #1 Failed.  Retrying \u21ba @ 12/09/24 13:47:51.041\n\n> Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:51.041\n< Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/utils/utils.go:25 @ 12/09/24 13:47:51.041 (0s)\n> Enter [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:51.041\n< Exit [BeforeEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:73 @ 12/09/24 13:47:51.047 (6ms)\n> Enter [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:51.047\nSTEP: Enable UserLevelNetworking and add Devices in Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:232 @ 12/09/24 13:47:51.43\n[FAILED] Expected\n    <int>: 4\nnot to equal\n    <int>: 4\nIn [It] at: /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:269 @ 12/09/24 13:47:56.989\n< Exit [It] [test_id:72051] Verify reserved cpus count is applied to all but specific supported networking device using a negative match - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:210 @ 12/09/24 13:47:56.989 (5.942s)\n> Enter [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:56.989\nSTEP: Reverting the Profile - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:90 @ 12/09/24 13:47:56.989\n< Exit [AfterEach] [ref_id: 40307][pao]Resizing Network Queues - /home/jenkins/workspace/CNF/cnf-compute-4.18/cluster-node-tuning-operator/test/e2e/performanceprofile/functests/1_performance/netqueues.go:89 @ 12/09/24 13:47:57.012 (23ms)\n"
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_failure_input.xml
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_failure_input.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<testsuites disabled="0" errors="0" failures="2" tests="2" time="0.044028282165527344">
+        <testsuite disabled="0" errors="0" failures="2" name="dci-openshift-app-agent" skipped="0" tests="2" time="0.044028282165527344">
+                <testcase classname="/usr/share/ansible/collections/ansible_collections/redhatci/ocp/roles/verify_tests/tasks/parse_junit_file.yml:19" name="[jumphost] Check test results step: redhatci.ocp.verify_tests : Fail if not all test results are as expected for cu_op_deploy_cloudran_site_new_version.xml msg=The following expectations failed: {{ expectation_failed }}" time="0.026203">
+                        <failure message="The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]" type="failure">{
+&quot;changed&quot;: false,
+&quot;msg&quot;: &quot;The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]&quot;
+}</failure>
+                </testcase>
+                <testcase classname="/usr/share/dci-openshift-app-agent/dci-openshift-app-agent.yml:271" name="[jumphost] Check test results step: Fail properly msg=Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/{{ job_info.job.id }}/jobStates" time="0.017825">
+                        <failure message="Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates" type="failure">{
+&quot;changed&quot;: false,
+&quot;msg&quot;: &quot;Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates&quot;
+}</failure>
+                </testcase>
+        </testsuite>
+</testsuites>

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_failure_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_failure_result.json
@@ -1,0 +1,48 @@
+{
+    "time": 0.044028282165527344,
+    "tests": 2,
+    "failures": 2,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "dci-openshift-app-agent",
+            "time": 0.044028282165527344,
+            "timestamp": "1970-01-01T00:00:00",
+            "tests": 2,
+            "failures": 2,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "[jumphost] Check test results step: redhatci.ocp.verify_tests : Fail if not all test results are as expected for cu_op_deploy_cloudran_site_new_version.xml msg=The following expectations failed: {{ expectation_failed }}",
+                    "classname": "/usr/share/ansible/collections/ansible_collections/redhatci/ocp/roles/verify_tests/tasks/parse_junit_file.yml:19",
+                    "time": 0.026203,
+                    "result": [
+                        {
+                            "failure_type": "failure",
+                            "message": "The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]",
+                            "text": "{\n\"changed\": false,\n\"msg\": \"The following expectations failed: [{'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_sites_deployment_time', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_managedcluster_ztp_done_label', 'passed': False}}, {'failed_expectation': {'testcase': '[a-zA-Z_]+', 'passed': True}, 'actual_result': {'testcase': 'test_policies_compliant', 'passed': False}}]\"\n}",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "[jumphost] Check test results step: Fail properly msg=Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/{{ job_info.job.id }}/jobStates",
+                    "classname": "/usr/share/dci-openshift-app-agent/dci-openshift-app-agent.yml:271",
+                    "time": 0.017825,
+                    "result": [
+                        {
+                            "failure_type": "failure",
+                            "message": "Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates",
+                            "text": "{\n\"changed\": false,\n\"msg\": \"Failure: Something went wrong, review the log at: https://www.distributed-ci.io/jobs/8b7e1fd4-9804-4abc-98c2-a9ecc39ba72c/jobStates\"\n}",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_simple_input.xml
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_simple_input.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" disabled="2" errors="0" failures="0" time="0.000426228">
+    <testsuite name="Performance Addon Operator Reboot" package="/home/jenkins/workspace/CNF/cnf-compute-4.18" 
+        tests="3" disabled="0" skipped="2" errors="0" failures="0" time="0.000426228" timestamp="2024-12-12T20:12:23">
+        <properties>
+            <property name="SuiteSucceeded" value="true"></property>
+            <property name="SuiteHasProgrammaticFocus" value="false"></property>
+            <property name="SpecialSuiteFailureReason" value=""></property>
+            <property name="SuiteLabels" value="[]"></property>
+            <property name="RandomSeed" value="1734025939"></property>
+            <property name="RandomizeAllSpecs" value="false"></property>
+            <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)"></property>
+            <property name="FocusStrings" value=""></property>
+            <property name="SkipStrings" value=""></property>
+            <property name="FocusFiles" value=""></property>
+            <property name="SkipFiles" value=""></property>
+            <property name="FailOnPending" value="false"></property>
+            <property name="FailOnEmpty" value="false"></property>
+            <property name="FailFast" value="false"></property>
+            <property name="FlakeAttempts" value="2"></property>
+            <property name="DryRun" value="false"></property>
+            <property name="ParallelTotal" value="1"></property>
+            <property name="OutputInterceptorMode" value=""></property>
+        </properties>
+        <testcase name="[It] [disruptive][node][kubelet][devicemanager]" classname="Performance Addon Operator Reboot" status="skipped" time="0">
+            <skipped message="skipped"></skipped>
+        </testcase>
+        <testcase name="Device management tests Verify that pods requesting devices" classname="Performance Addon Operator Reboot" status="skipped" time="0">
+            <skipped message="skipped"></skipped>
+        </testcase>
+        <testcase name="[ReportAfterSuite] e2e serial suite" classname="Performance Addon Operator Reboot" status="passed" time="6.826e-05">
+            <system-err>&gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;</system-err>
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_simple_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_simple_result.json
@@ -1,0 +1,75 @@
+{
+    "time": 0.000426228,
+    "tests": 3,
+    "failures": 0,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Performance Addon Operator Reboot",
+            "time": 0.000426228,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 3,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "true",
+                "SuiteHasProgrammaticFocus": "false",
+                "SpecialSuiteFailureReason": "",
+                "SuiteLabels": "[]",
+                "RandomSeed": "1734025939",
+                "RandomizeAllSpecs": "false",
+                "LabelFilter": "(!openshift && tier-0)",
+                "FocusStrings": "",
+                "SkipStrings": "",
+                "FocusFiles": "",
+                "SkipFiles": "",
+                "FailOnPending": "false",
+                "FailOnEmpty": "false",
+                "FailFast": "false",
+                "FlakeAttempts": "2",
+                "DryRun": "false",
+                "ParallelTotal": "1",
+                "OutputInterceptorMode": ""
+            },
+            "test_cases": [
+                {
+                    "name": "[It] [disruptive][node][kubelet][devicemanager]",
+                    "classname": "Performance Addon Operator Reboot",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Device management tests Verify that pods requesting devices",
+                    "classname": "Performance Addon Operator Reboot",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "[ReportAfterSuite] e2e serial suite",
+                    "classname": "Performance Addon Operator Reboot",
+                    "time": 6.826e-05,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ],
+                    "system_err": "> Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;"
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_simple_single_input.xml
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_junit2obj_simple_single_input.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Performance Addon Operator Reboot" package="/home/jenkins/workspace/CNF/cnf-compute-4.18" 
+    tests="3" disabled="0" skipped="2" errors="0" failures="0" time="0.000426228" timestamp="2024-12-12T20:12:23">
+    <properties>
+        <property name="SuiteSucceeded" value="true"></property>
+        <property name="SuiteHasProgrammaticFocus" value="false"></property>
+        <property name="SpecialSuiteFailureReason" value=""></property>
+        <property name="SuiteLabels" value="[]"></property>
+        <property name="RandomSeed" value="1734025939"></property>
+        <property name="RandomizeAllSpecs" value="false"></property>
+        <property name="LabelFilter" value="(!openshift &amp;&amp; tier-0)"></property>
+        <property name="FocusStrings" value=""></property>
+        <property name="SkipStrings" value=""></property>
+        <property name="FocusFiles" value=""></property>
+        <property name="SkipFiles" value=""></property>
+        <property name="FailOnPending" value="false"></property>
+        <property name="FailOnEmpty" value="false"></property>
+        <property name="FailFast" value="false"></property>
+        <property name="FlakeAttempts" value="2"></property>
+        <property name="DryRun" value="false"></property>
+        <property name="ParallelTotal" value="1"></property>
+        <property name="OutputInterceptorMode" value=""></property>
+    </properties>
+    <testcase name="[It] [disruptive][node][kubelet][devicemanager]" classname="Performance Addon Operator Reboot" status="skipped" time="0">
+        <skipped message="skipped"></skipped>
+    </testcase>
+    <testcase name="Device management tests Verify that pods requesting devices" classname="Performance Addon Operator Reboot" status="skipped" time="0">
+        <skipped message="skipped"></skipped>
+    </testcase>
+    <testcase name="[ReportAfterSuite] e2e serial suite" classname="Performance Addon Operator Reboot" status="passed" time="6.826e-05">
+        <system-err>&gt; Enter [ReportAfterSuite] TOP-LEVEL - /home/jenkins/workspace/CNF/cnf-compute-4.18;</system-err>
+    </testcase>
+</testsuite>

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_empty_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_empty_result.json
@@ -1,0 +1,10 @@
+{
+    "time": 0.0,
+    "tests": 0,
+    "failures": 0,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input1.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input1.json
@@ -1,0 +1,48 @@
+{
+    "time": 1.5,
+    "tests": 5,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input2.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input2.json
@@ -1,0 +1,59 @@
+{
+    "time": 2.0,
+    "tests": 3,
+    "failures": 0,
+    "errors": 1,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Test Suite 2",
+            "time": 2.0,
+            "timestamp": "2024-12-12T20:15:30",
+            "tests": 3,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "production"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 3",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "connection timeout",
+                            "status": "error"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 4",
+                    "classname": "TestClass2",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped due to environment",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 5",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_invalid.not_json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_invalid.not_json
@@ -1,0 +1,1 @@
+invalid json content

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_missing_test_suites.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_missing_test_suites.json
@@ -1,0 +1,7 @@
+{
+  "time": 1.0,
+  "tests": 1,
+  "failures": 0,
+  "errors": 0,
+  "skipped": 0
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_result.json
@@ -1,0 +1,20 @@
+{
+    "time": 2.5,
+    "tests": 3,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Valid Suite",
+            "time": 2.5,
+            "tests": 3,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 1,
+            "test_cases": []
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_valid.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_valid.json
@@ -1,0 +1,19 @@
+{
+  "time": 2.5,
+  "tests": 3,
+  "failures": 1,
+  "errors": 0,
+  "skipped": 1,
+  "test_suites": [
+    {
+      "name": "Valid Suite",
+      "time": 2.5,
+      "tests": 3,
+      "failures": 1,
+      "errors": 0,
+      "skipped": 1,
+      "test_cases": []
+    }
+  ],
+  "schema_version": "1.0.0"
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_multi_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_multi_result.json
@@ -1,0 +1,96 @@
+{
+    "time": 3.5,
+    "tests": 8,
+    "failures": 1,
+    "errors": 1,
+    "skipped": 3,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Test Suite 2",
+            "time": 2.0,
+            "timestamp": "2024-12-12T20:15:30",
+            "tests": 3,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "production"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 3",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "connection timeout",
+                            "status": "error"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 4",
+                    "classname": "TestClass2",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped due to environment",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 5",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_input.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_input.json
@@ -1,0 +1,34 @@
+{
+    "time": null,
+    "tests": null,
+    "failures": 1,
+    "errors": null,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "Test Suite with None Values",
+            "time": 1.0,
+            "timestamp": "2024-12-12T20:20:00",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "Test Case with None parent",
+                    "classname": "TestClassNone",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "test failed",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_result.json
@@ -1,0 +1,34 @@
+{
+    "time": 0.0,
+    "tests": 0,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "Test Suite with None Values",
+            "time": 1.0,
+            "timestamp": "2024-12-12T20:20:00",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "Test Case with None parent",
+                    "classname": "TestClassNone",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "test failed",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_single_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_single_result.json
@@ -1,0 +1,48 @@
+{
+    "time": 1.5,
+    "tests": 5,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/test_junit2obj.py
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/test_junit2obj.py
@@ -1,0 +1,90 @@
+#
+# Copyright (C) 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import json
+import os
+import pytest
+from importlib import import_module
+
+# Try importing junit2obj from multiple possible locations
+junit2obj = None
+import_attempts = [
+    "ansible_collections.redhatci.ocp.plugins.filter.junit2obj",
+    "plugins.filter.junit2obj", 
+    "filter_plugins.junit2obj"
+]
+
+for module_path in import_attempts:
+    try:
+        junit2obj = import_module(module_path)
+        break
+    except (ImportError, ModuleNotFoundError):
+        continue
+
+if junit2obj is None:
+    raise ImportError("junit2obj not found in any of the expected locations") from None
+
+
+# Calculate test data directory based on this test file's location
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, "data")
+
+
+def get_test_data_path(filename):
+    """Get absolute path to test data file"""
+    return os.path.join(DATA_DIR, filename)
+
+
+@pytest.fixture
+def input_data(request):  # type: ignore
+    file_path: str = str(request.param)  # type: ignore
+    with open(file_path, "r") as fd:
+        return fd.read()
+
+
+@pytest.fixture
+def expected_data_object(request):  # type: ignore
+    file_path: str = str(request.param)  # type: ignore
+    with open(file_path, "r") as fd:
+        return json.loads(fd.read())
+
+
+@pytest.mark.parametrize(
+    "input_data,expected_data_object",
+    [
+        (
+            get_test_data_path("test_junit2obj_simple_single_input.xml"),
+            get_test_data_path("test_junit2obj_simple_result.json"),
+        ),
+        (
+            get_test_data_path("test_junit2obj_simple_input.xml"),
+            get_test_data_path("test_junit2obj_simple_result.json"),
+        ),
+        (
+            get_test_data_path("test_junit2obj_failure_input.xml"),
+            get_test_data_path("test_junit2obj_failure_result.json"),
+        ),
+        (
+            get_test_data_path("test_junit2obj_complex_input.xml"),
+            get_test_data_path("test_junit2obj_complex_result.json"),
+        ),
+    ],
+    indirect=True,
+)
+def test_simple_data_object_true(input_data, expected_data_object):  # type: ignore
+    filter = junit2obj.FilterModule()
+    actual: str = filter.filters()["junit2obj"](input_data)  # type: ignore
+    assert expected_data_object == actual

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/test_reportsmerger.py
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/test_reportsmerger.py
@@ -1,0 +1,353 @@
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from importlib import import_module
+
+# Try importing reportsmerger from multiple possible locations
+reportsmerger = None
+import_attempts = [
+    "ansible_collections.redhatci.ocp.plugins.filter.reportsmerger",
+    "plugins.filter.reportsmerger",
+    "filter_plugins.reportsmerger"
+]
+
+for module_path in import_attempts:
+    try:
+        reportsmerger = import_module(module_path)
+        break
+    except (ImportError, ModuleNotFoundError):
+        continue
+
+if reportsmerger is None:
+    raise ImportError("reportsmerger not found in any of the expected locations") from None
+
+
+# Calculate test data directory based on this test file's location
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, "data")
+
+
+def get_test_data_path(filename):
+    """Get absolute path to test data file"""
+    return os.path.join(DATA_DIR, filename)
+
+
+@pytest.fixture
+def json_loader():
+    """Factory fixture that returns a function to load JSON from file paths"""
+    def _load_json_file(file_path: str):
+        with open(file_path, "r") as fd:
+            return json.loads(fd.read())
+    return _load_json_file
+
+
+@pytest.fixture
+def expected_data_object(request, json_loader):  # type: ignore
+    """Load expected data using the json_loader fixture"""
+    file_path: str = str(request.param)  # type: ignore
+    return json_loader(file_path)
+
+
+@pytest.mark.parametrize(
+    "input_files,expected_data_object",
+    [
+        # Single file test
+        (
+            [
+                get_test_data_path("test_reportsmerger_input1.json"),
+            ],
+            get_test_data_path("test_reportsmerger_single_result.json"),
+        ),
+        # Multiple files test
+        (
+            [
+                get_test_data_path("test_reportsmerger_input1.json"),
+                get_test_data_path("test_reportsmerger_input2.json"),
+            ],
+            get_test_data_path("test_reportsmerger_multi_result.json"),
+        ),
+        # None values test
+        (
+            [
+                get_test_data_path("test_reportsmerger_none_input.json"),
+            ],
+            get_test_data_path("test_reportsmerger_none_result.json"),
+        ),
+        # Mixed existing files test (valid files only, ignoring missing ones)
+        (
+            [
+                get_test_data_path("test_reportsmerger_mixed_valid.json"),
+            ],
+            get_test_data_path("test_reportsmerger_mixed_result.json"),
+        ),
+    ],
+    indirect=["expected_data_object"],
+)
+def test_reportsmerger_with_static_data(input_files, expected_data_object):  # type: ignore
+    """Test reportsmerger filter with static test data files"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Test the filter with the input files (reportsmerger expects file paths)
+    actual = filter_plugin.filters()["reportsmerger"](input_files)  # type: ignore
+
+    # Compare with expected result (accounting for schema version difference)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_data_object[key] == actual[key]
+    assert actual["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_empty_list():
+    """Test error handling for empty file list"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    with pytest.raises(ValueError, match="requires at least one filename"):
+        filter_plugin.filters()["reportsmerger"]([])
+
+
+def test_reportsmerger_invalid_input():
+    """Test error handling for non-list input"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    with pytest.raises(TypeError, match="expects a list of filenames"):
+        filter_plugin.filters()["reportsmerger"]("not_a_list")
+
+
+def test_reportsmerger_missing_file(json_loader):
+    """Test handling of missing files (should emit warning and skip)"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    expected_data: str = get_test_data_path("test_reportsmerger_empty_result.json")
+    # Load expected empty result using json_loader fixture
+    expected_result = json_loader(expected_data)
+
+    # Mock the Display class to capture warning calls
+    with patch.object(reportsmerger, 'Display') as mock_display_class:
+        mock_display = MagicMock()
+        mock_display_class.return_value = mock_display
+
+        fname: str = "nonexistent_file.json"
+        # Test with only missing files - should return empty result
+        result = filter_plugin.filters()["reportsmerger"]([fname])
+
+        # Verify warning was called with correct message
+        mock_display.warning.assert_called_once_with(
+            f"reportsmerger plugin: file {fname} does not exist and was skipped"
+        )
+
+    # Compare with expected result from static file (accounting for schema version)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == result[key]
+    assert result["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_mixed_existing_missing_files(json_loader):
+    """Test handling of mix of existing and missing files"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static test data files
+    valid_file: str = get_test_data_path("test_reportsmerger_mixed_valid.json")
+    expected_data: str = get_test_data_path("test_reportsmerger_mixed_result.json")
+    # Load expected result using json_loader fixture
+    expected_result = json_loader(expected_data)
+
+    # Mock the Display class to capture warning calls
+    with patch.object(reportsmerger, 'Display') as mock_display_class:
+        mock_display = MagicMock()
+        mock_display_class.return_value = mock_display
+        fname = "nonexistent"
+        missing_files_list = [f"{fname}{i}.json" for i in range(1, 3)]
+        files_list = missing_files_list + [valid_file]
+        # Test with mix of existing and missing files
+        result = filter_plugin.filters()["reportsmerger"](files_list)
+        # Verify warnings were called for missing files
+        expected_warnings = [f"reportsmerger plugin: file {f} does not exist and was skipped" for f in missing_files_list]
+
+        assert mock_display.warning.call_count == len(missing_files_list)
+        actual_warning_calls = [call[0][0] for call in mock_display.warning.call_args_list]
+        assert actual_warning_calls == expected_warnings
+
+    # Compare with expected result from static file (accounting for schema version)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == result[key]
+    assert result["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_invalid_json(json_loader):
+    """Test error handling for invalid JSON"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static invalid JSON file
+    test_file: str = get_test_data_path("test_reportsmerger_invalid.not_json")
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        filter_plugin.filters()["reportsmerger"]([test_file])
+
+
+def test_reportsmerger_missing_test_suites(json_loader):
+    """Test error handling for missing test_suites field"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static file with missing test_suites field
+    test_file: str = get_test_data_path("test_reportsmerger_missing_test_suites.json")
+
+    with pytest.raises(ValueError, match="Missing 'test_suites' field"):
+        filter_plugin.filters()["reportsmerger"]([test_file])
+
+
+# New tests for strategy parameter
+def test_reportsmerger_strategy_validation():
+    """Test strategy parameter validation"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Test invalid strategy
+    with pytest.raises(ValueError, match="Invalid strategy 'invalid'"):
+        filter_plugin.filters()["reportsmerger"](
+            [get_test_data_path("test_reportsmerger_input1.json")], 
+            strategy="invalid"
+        )
+
+
+@pytest.mark.parametrize("strategy", ["normal", "large", "many"])
+def test_reportsmerger_compatible_strategies(strategy, json_loader):
+    """Test that compatible strategies produce equivalent results for simple case"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    input_files = [get_test_data_path("test_reportsmerger_input1.json")]
+    expected_data = get_test_data_path("test_reportsmerger_single_result.json")
+    expected_result = json_loader(expected_data)
+
+    # Test each strategy
+    actual = filter_plugin.filters()["reportsmerger"](input_files, strategy=strategy)
+
+    # These strategies should produce equivalent results (except schema_version)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == actual[key]
+
+    # Schema version will be different (1.1.0 vs 1.0.0)
+    assert actual["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_strategy_large_streaming(json_loader):
+    """Test large strategy specifically for memory efficiency"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    input_files = [
+        get_test_data_path("test_reportsmerger_input1.json"),
+        get_test_data_path("test_reportsmerger_input2.json"),
+    ]
+    expected_data = get_test_data_path("test_reportsmerger_multi_result.json")
+    expected_result = json_loader(expected_data)
+
+    actual = filter_plugin.filters()["reportsmerger"](input_files, strategy="large")
+
+    # Compare all fields except schema_version
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == actual[key]
+    assert actual["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_strategy_many_parallel(json_loader):
+    """Test many strategy specifically for parallel processing"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    input_files = [
+        get_test_data_path("test_reportsmerger_input1.json"),
+        get_test_data_path("test_reportsmerger_input2.json"),
+    ]
+    expected_data = get_test_data_path("test_reportsmerger_multi_result.json")
+    expected_result = json_loader(expected_data)
+
+    actual = filter_plugin.filters()["reportsmerger"](input_files, strategy="many")
+
+    # Compare all fields except schema_version
+    for key in ["time", "tests", "failures", "errors", "skipped"]:
+        assert expected_result[key] == actual[key]
+
+    # For parallel processing, test_suites order might differ, so sort by name for comparison
+    expected_suites = sorted(expected_result["test_suites"], key=lambda x: x["name"])
+    actual_suites = sorted(actual["test_suites"], key=lambda x: x["name"])
+    assert expected_suites == actual_suites
+
+    assert actual["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_strategy_shallow_lazy(json_loader):
+    """Test shallow strategy with lazy test suites loading"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    input_files = [get_test_data_path("test_reportsmerger_input1.json")]
+    expected_data = get_test_data_path("test_reportsmerger_single_result.json")
+    expected_result = json_loader(expected_data)
+
+    actual = filter_plugin.filters()["reportsmerger"](input_files, strategy="shallow")
+
+    # Stats should match (except schema_version)
+    for key in ["time", "tests", "failures", "errors", "skipped"]:
+        assert expected_result[key] == actual[key]
+    assert actual["schema_version"] == "1.1.0"
+
+    # Test suites should be lazy-loaded but equivalent when accessed
+    assert len(actual["test_suites"]) == len(expected_result["test_suites"])
+    assert list(actual["test_suites"]) == expected_result["test_suites"]
+
+
+def test_reportsmerger_strategy_complex_parsing(json_loader):
+    """Test complex strategy with schema-specific parsing"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    input_files = [get_test_data_path("test_reportsmerger_input1.json")]
+    expected_data = get_test_data_path("test_reportsmerger_single_result.json")
+    expected_result = json_loader(expected_data)
+
+    actual = filter_plugin.filters()["reportsmerger"](input_files, strategy="complex")
+
+    # Stats should match exactly (except schema_version)
+    for key in ["time", "tests", "failures", "errors", "skipped"]:
+        assert expected_result[key] == actual[key]
+    assert actual["schema_version"] == "1.1.0"
+
+    # Test suites should have empty test_cases (complex strategy optimization)
+    assert len(actual["test_suites"]) == len(expected_result["test_suites"])
+    for suite in actual["test_suites"]:
+        assert suite["test_cases"] == []  # Should be empty due to complex parsing
+        # But should have the count preserved
+        if "_original_test_cases_count" in suite:
+            assert suite["_original_test_cases_count"] >= 0
+
+
+def test_reportsmerger_default_strategy_backward_compatibility(json_loader):
+    """Test that default behavior (no strategy param) works as before"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    input_files = [get_test_data_path("test_reportsmerger_input1.json")]
+    expected_data = get_test_data_path("test_reportsmerger_single_result.json") 
+    expected_result = json_loader(expected_data)
+
+    # Test without strategy parameter (should default to "normal")
+    actual_default = filter_plugin.filters()["reportsmerger"](input_files)
+    actual_normal = filter_plugin.filters()["reportsmerger"](input_files, strategy="normal")
+
+    # Both should be identical
+    assert actual_default == actual_normal
+
+    # Compare with expected result (accounting for schema version difference)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == actual_default[key]
+    assert actual_default["schema_version"] == "1.1.0"

--- a/playbooks/infra/reporting/roles/junit2json/vars/dummy_variables.yml
+++ b/playbooks/infra/reporting/roles/junit2json/vars/dummy_variables.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# Dummy variables to prevent Jinja2 template evaluation errors
+# when processing test data that contains literal {{ }} strings
+
+# This file defines placeholder values for any template-like strings
+# that appear in test data but are not meant to be evaluated as templates
+
+junit2_dummy_variables:
+  # Common test failure message placeholders
+  expectation_failed: "PLACEHOLDER_EXPECTATION_FAILED"
+
+  # Job and CI system placeholders
+  job_info:
+    job:
+      id: "PLACEHOLDER_JOB_ID"
+      name: "PLACEHOLDER_JOB_NAME"
+      url: "PLACEHOLDER_JOB_URL"
+    build:
+      number: "PLACEHOLDER_BUILD_NUMBER"
+      url: "PLACEHOLDER_BUILD_URL"
+
+  # CI/CD system placeholders
+  ci_job_id: "PLACEHOLDER_CI_JOB_ID"
+  ci_build_id: "PLACEHOLDER_CI_BUILD_ID"
+  ci_pipeline_id: "PLACEHOLDER_CI_PIPELINE_ID"
+
+  # Test environment placeholders
+  test_environment: "PLACEHOLDER_TEST_ENV"
+  cluster_name: "PLACEHOLDER_CLUSTER_NAME"
+  namespace: "PLACEHOLDER_NAMESPACE"
+
+  # Common error message placeholders
+  error_message: "PLACEHOLDER_ERROR_MESSAGE"
+  failure_reason: "PLACEHOLDER_FAILURE_REASON"
+  exception_details: "PLACEHOLDER_EXCEPTION_DETAILS"
+
+  # Timestamp placeholders
+  timestamp: "PLACEHOLDER_TIMESTAMP"
+  test_start_time: "PLACEHOLDER_TEST_START_TIME"
+  test_end_time: "PLACEHOLDER_TEST_END_TIME"
+# You can extend this list by adding any new template-like strings
+# that appear in your test data files

--- a/playbooks/infra/reporting/roles/junit2json/vars/main.yml
+++ b/playbooks/infra/reporting/roles/junit2json/vars/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+---
+# vars file for junit2json
+
+junit2_json_reports_list: []


### PR DESCRIPTION
implements:
1. filter plugin `junuit2obj` converts a junit xml report to json report of similar structure
2. filter plugin `reportsmerger` merges several json reports into 1 big report, updating aggregate metrics (counters, times)
3. role `junit2json` the role to be used to convert and merge junit xml reports
4. unit tests for both plugins