### PR TITLE
fix issue where NTO image was not found

### DIFF
--- a/playbooks/compute/nto/roles/configurecluster/defaults/main.yml
+++ b/playbooks/compute/nto/roles/configurecluster/defaults/main.yml
@@ -7,7 +7,6 @@ high_power_consumption: false
 per_pod_power_management: false
 must_gather_dir: "/mustgather"
 container_runtime: "runc"
-nto_image: registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cluster-node-tuning-rhel9-operator
 
 mcp_wait_retries: 180
 mcp_wait_delay: 30

--- a/playbooks/compute/nto/roles/configurecluster/tasks/ppc.yml
+++ b/playbooks/compute/nto/roles/configurecluster/tasks/ppc.yml
@@ -34,13 +34,14 @@
 
 - name: Set Image version
   ansible.builtin.set_fact:
-    nto_sha: "{{ (nto_deployment.resources[0].spec.template.spec.containers[0].image | split(':'))[1] }}"
+    nto_image: "{{ nto_deployment.resources[0].spec.template.spec.containers[0].image }}"
 
 - name: Generate performance profile
   ansible.builtin.shell: |
       set -o pipefail
       podman run --rm --tls-verify=false --entrypoint performance-profile-creator -v \
-            {{ must_gather_dir }}:{{ must_gather_dir }}:z {{ nto_image }}@sha256:{{ nto_sha }}  \
+            --authfile "{{ pull_secret_string | b64decode }}" \
+            {{ must_gather_dir }}:{{ must_gather_dir }}:z {{ nto_image }}  \
             --must-gather-dir-path {{ must_gather_dir }} --rt-kernel={{ rt_kernel }} \
             --mcp-name worker-cnf --reserved-cpu-count=4 --topology-manager-policy=single-numa-node \
             --power-consumption-mode ultra-low-latency --user-level-networking | tee /tmp/performanceprofile-spec.yaml


### PR DESCRIPTION
- using the nto image from the container instead of building a string