### PR TITLE
## adding plugin filter `reportsmerger` + tests

### DIFF
--- a/playbooks/infra/reporting/roles/junit2json/doc/reportsmerger.md
+++ b/playbooks/infra/reporting/roles/junit2json/doc/reportsmerger.md
@@ -1,0 +1,51 @@
+# Filter plugin `reportsmerger`
+
+Aggregates N JSON reports into 1 consolidated test report.
+
+## Usage
+
+```yaml
+---
+- name: merge files into variable my_var
+  ansible.builtin.set_fact:
+    my_var: "{{ ['f1.json', 'f2.json'] | reportsmerger }}"
+
+- name: merge files and output to file
+  ansible.builtin.set_fact:
+    result_path: "{{ ['f1.json', 'f2.json'] | reportsmerger(output='result.json') }}"
+```
+
+## Parameters
+
+- **filenames** (required): List of JSON file paths to merge
+- **output** (optional): File path to write merged data. When specified, returns the file path instead of the merged data
+
+## Examples
+
+```yaml
+# Basic merge - returns merged data
+- name: merge test reports
+  ansible.builtin.set_fact:
+    merged_data: "{{ report_files | reportsmerger }}"
+
+# Save to file - returns file path
+- name: merge and save to file
+  ansible.builtin.set_fact:
+    output_file: "{{ report_files | reportsmerger(output='/tmp/merged.json') }}"
+
+# Access merged statistics
+- debug:
+    msg: "Total tests: {{ merged_data.tests }}, Failures: {{ merged_data.failures }}"
+```
+
+## Output Format
+
+The merged report contains:
+
+- **time**: Total execution time from all test suites (float)
+- **tests**: Total number of tests (int)
+- **failures**: Total number of failures (int)
+- **errors**: Total number of errors (int)
+- **skipped**: Total number of skipped tests (int)
+- **test_suites**: Combined list of all test suites from input files (list)
+- **schema_version**: Schema version (string)

--- a/playbooks/infra/reporting/roles/junit2json/filter_plugins/reportsmerger.py
+++ b/playbooks/infra/reporting/roles/junit2json/filter_plugins/reportsmerger.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+"""Ansible filter plugin that merges multiple json files into one
+
+The files should be the result of junit2obj conversion
+"""
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import absolute_import, division, print_function
+from __future__ import annotations
+from typing import Any
+from ansible.utils.display import Display
+
+# pylint: disable=invalid-name
+__metaclass__ = type
+__version__ = "1.1.0"
+
+DOCUMENTATION = r"""
+---
+name: reportsmerger
+version_added: "1.1.0"
+short_description: merge multiple similarly built JSON files into one
+description: >
+  This filter plugin merges multiple test report JSON files (usually
+  converted by junit2obj filter) into a single consolidated test report.
+  It combines all test suites and recalculates aggregated statistics.
+positional: filenames
+options:
+  filenames:
+    description: List of filenames containing test report JSON data
+    type: list
+    elements: str
+    required: true
+  output:
+    description: Optional output file path to write merged data
+    type: str
+    required: false
+"""
+
+EXAMPLES = r"""
+---
+# Basic usage - merge multiple test report files
+- name: merge reports (default strategy)
+  ansible.builtin.set_fact:
+    merged: "{{ ['1.json', '2.json', '3.json'] | reportsmerger }}"
+
+# Use optimization strategies for different scenarios
+- name: merge large files with memory optimization
+  ansible.builtin.set_fact:
+    merged: "{{ large_files | reportsmerger) }}"
+
+# Write output directly to file
+- name: merge and save to file
+  ansible.builtin.set_fact:
+    output_path: "{{ files | reportsmerger(output='/tmp/merged.json') }}"
+"""
+
+RETURN = r"""
+---
+_value:
+  description:
+    - Merged test report data structure
+  type: dict
+  contains:
+    time:
+      description: Total time from all test suites
+      type: float
+    tests:
+      description: Total number of tests
+      type: int
+    failures:
+      description: Total number of failures
+      type: int
+    errors:
+      description: Total number of errors
+      type: int
+    skipped:
+      description: Total number of skipped tests
+      type: int
+    test_suites:
+      description: Combined list of all test suites from input files
+      type: list
+    schema_version:
+      description: Schema version
+      type: str
+"""
+
+
+class FilterModule:
+    """
+    Filter for merging multiple test report JSON files
+    """
+
+    def filters(self) -> dict[str, Any]:
+        """
+        filter boilerplate
+        """
+        return {
+            "reportsmerger": self.reportsmerger,
+        }
+
+    # pylint: disable=bad-whitespace
+    def reportsmerger(
+        self,
+        filenames: list[str],
+        output: str | None = None,
+    ) -> dict[str, Any] | str:
+        """
+        Merge multiple test report JSON files into a single test report.
+
+        Args:
+            filenames: List of file paths containing test report JSON data
+            strategy: Optimization strategy to use:
+                     - "normal": Default behavior (backward compatible)
+                     - "large": Streaming aggregation for large files (low memory)
+                     - "many": Parallel processing for many files (faster I/O)
+                     - "shallow": Lazy test suites loading (stats-only focus)
+                     - "complex": Schema-specific parsing (skip heavy test_cases)
+            output: Optional output file path. If provided, writes merged
+                         data to file and returns the file path instead of
+                         the data
+
+        Returns:
+            dict: Merged report with aggregated statistics (if no output_file)
+            str: Output file path (if output_file provided)
+        """
+        import json
+
+        display = Display()
+        if not isinstance(filenames, list):
+            raise TypeError("reportsmerger expects a list of filenames")
+        if not filenames:
+            raise ValueError("reportsmerger requires at least one filename")
+
+        # Validate output_file parameter
+        if output and not isinstance(output, str):
+            raise ValueError("output must be a string")
+
+        merged_report = self._strategy_normal(filenames, display)
+
+        display.v("\n".join(
+            [
+                f"Merged {len(filenames)} files:",
+                f"  tests:\t{merged_report['tests']}",
+                f"  failures:\t{merged_report['failures']}",
+                f"  errors:\t{merged_report['errors']}",
+                f"  skipped:\t{merged_report['skipped']}",
+                f"  time:\t{merged_report['time']}",
+                f"  test_suites:\t{len(merged_report['test_suites'])}",
+            ]
+        ))
+
+        # NEW: If output file specified, write directly and return path
+        if output:
+            with open(output, "w", encoding="utf-8") as f:
+                json.dump(merged_report, f, indent=2)
+            display.v(f"Merged report written to {output}")
+            return output  # Return just the path, not the data
+
+        # Original behavior: return the data
+        return merged_report
+
+    def _load_and_validate_report(
+        self, filename: str, display: Display
+    ) -> dict[str, Any]:
+        """Load and validate a single report file."""
+        import json
+
+        try:
+            with open(filename, "r", encoding="utf-8") as f:
+                report_data: dict[str, Any] = json.load(f)
+        except json.JSONDecodeError as jde:
+            msg = f"Invalid JSON in file {filename}: {jde}"
+            display.error(msg)
+            raise ValueError(msg) from jde
+        except Exception as exc:
+            msg = f"Error reading file {filename}: {exc}"
+            display.error(msg)
+            raise RuntimeError(msg) from exc
+
+        # Validate required fields
+        if "test_suites" not in report_data:
+            msg = f"Missing 'test_suites' field in {filename}"
+            display.error(msg)
+            raise ValueError(msg)
+
+        return report_data
+
+    def _accumulate_report_stats(
+        self,
+        report_data: dict[str, Any],
+        merged_report: dict[str, Any],
+        filename: str,
+        display: Display,
+    ) -> None:
+        """Accumulate statistics from a report into the merged report."""
+        # Update numeric statistics directly in merged_report
+        for field in ["time", "tests", "failures", "errors", "skipped"]:
+            value = report_data.get(field, 0.0 if field == "time" else 0)
+            if value is None:
+                # Handle None values by treating them as 0
+                value = 0.0 if field == "time" else 0
+            try:
+                if field == "time":
+                    merged_report[field] += float(value)
+                else:
+                    merged_report[field] += int(value)
+            except (ValueError, TypeError) as e:
+                msg = f"Invalid numeric data in {filename}: {e}"
+                display.error(msg)
+                raise ValueError(msg) from e
+
+        # Merge test suites
+        test_suites = report_data.get("test_suites", [])
+        if not isinstance(test_suites, list):
+            msg = f"Invalid 'test_suites' format in {filename}: expected list"
+            display.error(msg)
+            raise ValueError(msg)
+
+        merged_report["test_suites"].extend(test_suites)
+        msg = f"Successfully processed {filename}: {report_data.get('tests', 0)} tests"
+        display.vv(msg)
+
+    def _strategy_normal(self, filenames: list[str], display: Display) -> dict[str, Any]:
+        """Normal strategy - current behavior (backward compatible)"""
+        import os
+
+        merged_report: dict[str, Any] = {
+            "time": 0.0,
+            "tests": 0,
+            "failures": 0,
+            "errors": 0,
+            "skipped": 0,
+            "test_suites": [],
+            "schema_version": __version__,
+        }
+
+        for filename in filenames:
+            if not os.path.exists(filename):
+                msg = (
+                    f"reportsmerger plugin: file {filename} "
+                    "does not exist and was skipped"
+                )
+                display.warning(msg)
+                continue
+
+            report_data = self._load_and_validate_report(filename, display)
+            self._accumulate_report_stats(report_data, merged_report, filename, display)
+
+        return merged_report

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_empty_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_empty_result.json
@@ -1,0 +1,10 @@
+{
+    "time": 0.0,
+    "tests": 0,
+    "failures": 0,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input1.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input1.json
@@ -1,0 +1,48 @@
+{
+    "time": 1.5,
+    "tests": 5,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input2.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_input2.json
@@ -1,0 +1,59 @@
+{
+    "time": 2.0,
+    "tests": 3,
+    "failures": 0,
+    "errors": 1,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Test Suite 2",
+            "time": 2.0,
+            "timestamp": "2024-12-12T20:15:30",
+            "tests": 3,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "production"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 3",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "connection timeout",
+                            "status": "error"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 4",
+                    "classname": "TestClass2",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped due to environment",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 5",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_invalid.not_json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_invalid.not_json
@@ -1,0 +1,1 @@
+invalid json content

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_missing_test_suites.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_missing_test_suites.json
@@ -1,0 +1,7 @@
+{
+  "time": 1.0,
+  "tests": 1,
+  "failures": 0,
+  "errors": 0,
+  "skipped": 0
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_result.json
@@ -1,0 +1,20 @@
+{
+    "time": 2.5,
+    "tests": 3,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 1,
+    "test_suites": [
+        {
+            "name": "Valid Suite",
+            "time": 2.5,
+            "tests": 3,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 1,
+            "test_cases": []
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_valid.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_mixed_valid.json
@@ -1,0 +1,19 @@
+{
+  "time": 2.5,
+  "tests": 3,
+  "failures": 1,
+  "errors": 0,
+  "skipped": 1,
+  "test_suites": [
+    {
+      "name": "Valid Suite",
+      "time": 2.5,
+      "tests": 3,
+      "failures": 1,
+      "errors": 0,
+      "skipped": 1,
+      "test_cases": []
+    }
+  ],
+  "schema_version": "1.0.0"
+}

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_multi_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_multi_result.json
@@ -1,0 +1,96 @@
+{
+    "time": 3.5,
+    "tests": 8,
+    "failures": 1,
+    "errors": 1,
+    "skipped": 3,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Test Suite 2",
+            "time": 2.0,
+            "timestamp": "2024-12-12T20:15:30",
+            "tests": 3,
+            "failures": 0,
+            "errors": 1,
+            "skipped": 1,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "production"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 3",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "connection timeout",
+                            "status": "error"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 4",
+                    "classname": "TestClass2",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped due to environment",
+                            "status": "skipped"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 5",
+                    "classname": "TestClass2",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "passed",
+                            "status": "passed"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_input.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_input.json
@@ -1,0 +1,34 @@
+{
+    "time": null,
+    "tests": null,
+    "failures": 1,
+    "errors": null,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "Test Suite with None Values",
+            "time": 1.0,
+            "timestamp": "2024-12-12T20:20:00",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "Test Case with None parent",
+                    "classname": "TestClassNone",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "test failed",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_none_result.json
@@ -1,0 +1,34 @@
+{
+    "time": 0.0,
+    "tests": 0,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 0,
+    "test_suites": [
+        {
+            "name": "Test Suite with None Values",
+            "time": 1.0,
+            "timestamp": "2024-12-12T20:20:00",
+            "tests": 1,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 0,
+            "properties": {},
+            "test_cases": [
+                {
+                    "name": "Test Case with None parent",
+                    "classname": "TestClassNone",
+                    "time": 1.0,
+                    "result": [
+                        {
+                            "message": "test failed",
+                            "status": "failure"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_single_result.json
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/data/test_reportsmerger_single_result.json
@@ -1,0 +1,48 @@
+{
+    "time": 1.5,
+    "tests": 5,
+    "failures": 1,
+    "errors": 0,
+    "skipped": 2,
+    "test_suites": [
+        {
+            "name": "Test Suite 1",
+            "time": 1.5,
+            "timestamp": "2024-12-12T20:12:23",
+            "tests": 5,
+            "failures": 1,
+            "errors": 0,
+            "skipped": 2,
+            "properties": {
+                "SuiteSucceeded": "false",
+                "Environment": "test"
+            },
+            "test_cases": [
+                {
+                    "name": "Test Case 1",
+                    "classname": "TestClass1",
+                    "time": 0.5,
+                    "result": [
+                        {
+                            "message": "assertion failed",
+                            "status": "failure"
+                        }
+                    ]
+                },
+                {
+                    "name": "Test Case 2",
+                    "classname": "TestClass1",
+                    "time": 0.0,
+                    "result": [
+                        {
+                            "message": "skipped",
+                            "status": "skipped"
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "schema_version": "1.0.0"
+}
+

--- a/playbooks/infra/reporting/roles/junit2json/tests/unit/test_reportsmerger.py
+++ b/playbooks/infra/reporting/roles/junit2json/tests/unit/test_reportsmerger.py
@@ -1,0 +1,211 @@
+# Copyright (C) 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+import json
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+from importlib import import_module
+
+# Try importing reportsmerger from multiple possible locations
+reportsmerger = None
+import_attempts = [
+    "ansible_collections.redhatci.ocp.plugins.filter.reportsmerger",
+    "plugins.filter.reportsmerger",
+    "filter_plugins.reportsmerger"
+]
+
+for module_path in import_attempts:
+    try:
+        reportsmerger = import_module(module_path)
+        break
+    except (ImportError, ModuleNotFoundError):
+        continue
+
+if reportsmerger is None:
+    raise ImportError("reportsmerger not found in any of the expected locations") from None
+
+
+# Calculate test data directory based on this test file's location
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(TEST_DIR, "data")
+
+
+def get_test_data_path(filename):
+    """Get absolute path to test data file"""
+    return os.path.join(DATA_DIR, filename)
+
+
+@pytest.fixture
+def json_loader():
+    """Factory fixture that returns a function to load JSON from file paths"""
+    def _load_json_file(file_path: str):
+        with open(file_path, "r") as fd:
+            return json.loads(fd.read())
+    return _load_json_file
+
+
+@pytest.fixture
+def expected_data_object(request, json_loader):  # type: ignore
+    """Load expected data using the json_loader fixture"""
+    file_path: str = str(request.param)  # type: ignore
+    return json_loader(file_path)
+
+
+@pytest.mark.parametrize(
+    "input_files,expected_data_object",
+    [
+        # Single file test
+        (
+            [
+                get_test_data_path("test_reportsmerger_input1.json"),
+            ],
+            get_test_data_path("test_reportsmerger_single_result.json"),
+        ),
+        # Multiple files test
+        (
+            [
+                get_test_data_path("test_reportsmerger_input1.json"),
+                get_test_data_path("test_reportsmerger_input2.json"),
+            ],
+            get_test_data_path("test_reportsmerger_multi_result.json"),
+        ),
+        # None values test
+        (
+            [
+                get_test_data_path("test_reportsmerger_none_input.json"),
+            ],
+            get_test_data_path("test_reportsmerger_none_result.json"),
+        ),
+        # Mixed existing files test (valid files only, ignoring missing ones)
+        (
+            [
+                get_test_data_path("test_reportsmerger_mixed_valid.json"),
+            ],
+            get_test_data_path("test_reportsmerger_mixed_result.json"),
+        ),
+    ],
+    indirect=["expected_data_object"],
+)
+def test_reportsmerger_with_static_data(input_files, expected_data_object):  # type: ignore
+    """Test reportsmerger filter with static test data files"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Test the filter with the input files (reportsmerger expects file paths)
+    actual = filter_plugin.filters()["reportsmerger"](input_files)  # type: ignore
+
+    # Compare with expected result (accounting for schema version difference)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_data_object[key] == actual[key]
+    assert actual["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_empty_list():
+    """Test error handling for empty file list"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    with pytest.raises(ValueError, match="requires at least one filename"):
+        filter_plugin.filters()["reportsmerger"]([])
+
+
+def test_reportsmerger_invalid_input():
+    """Test error handling for non-list input"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    with pytest.raises(TypeError, match="expects a list of filenames"):
+        filter_plugin.filters()["reportsmerger"]("not_a_list")
+
+
+def test_reportsmerger_missing_file(json_loader):
+    """Test handling of missing files (should emit warning and skip)"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    expected_data: str = get_test_data_path("test_reportsmerger_empty_result.json")
+    # Load expected empty result using json_loader fixture
+    expected_result = json_loader(expected_data)
+
+    # Mock the Display class to capture warning calls
+    with patch.object(reportsmerger, 'Display') as mock_display_class:
+        mock_display = MagicMock()
+        mock_display_class.return_value = mock_display
+
+        fname: str = "nonexistent_file.json"
+        # Test with only missing files - should return empty result
+        result = filter_plugin.filters()["reportsmerger"]([fname])
+
+        # Verify warning was called with correct message
+        mock_display.warning.assert_called_once_with(
+            f"reportsmerger plugin: file {fname} does not exist and was skipped"
+        )
+
+    # Compare with expected result from static file (accounting for schema version)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == result[key]
+    assert result["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_mixed_existing_missing_files(json_loader):
+    """Test handling of mix of existing and missing files"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static test data files
+    valid_file: str = get_test_data_path("test_reportsmerger_mixed_valid.json")
+    expected_data: str = get_test_data_path("test_reportsmerger_mixed_result.json")
+    # Load expected result using json_loader fixture
+    expected_result = json_loader(expected_data)
+
+    # Mock the Display class to capture warning calls
+    with patch.object(reportsmerger, 'Display') as mock_display_class:
+        mock_display = MagicMock()
+        mock_display_class.return_value = mock_display
+        fname = "nonexistent"
+        missing_files_list = [f"{fname}{i}.json" for i in range(1, 3)]
+        files_list = missing_files_list + [valid_file]
+        # Test with mix of existing and missing files
+        result = filter_plugin.filters()["reportsmerger"](files_list)
+        # Verify warnings were called for missing files
+        expected_warnings = [f"reportsmerger plugin: file {f} does not exist and was skipped" for f in missing_files_list]
+
+        assert mock_display.warning.call_count == len(missing_files_list)
+        actual_warning_calls = [call[0][0] for call in mock_display.warning.call_args_list]
+        assert actual_warning_calls == expected_warnings
+
+    # Compare with expected result from static file (accounting for schema version)
+    for key in ["time", "tests", "failures", "errors", "skipped", "test_suites"]:
+        assert expected_result[key] == result[key]
+    assert result["schema_version"] == "1.1.0"
+
+
+def test_reportsmerger_invalid_json(json_loader):
+    """Test error handling for invalid JSON"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static invalid JSON file
+    test_file: str = get_test_data_path("test_reportsmerger_invalid.not_json")
+
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        filter_plugin.filters()["reportsmerger"]([test_file])
+
+
+def test_reportsmerger_missing_test_suites(json_loader):
+    """Test error handling for missing test_suites field"""
+    filter_plugin = reportsmerger.FilterModule()
+
+    # Use static file with missing test_suites field
+    test_file: str = get_test_data_path("test_reportsmerger_missing_test_suites.json")
+
+    with pytest.raises(ValueError, match="Missing 'test_suites' field"):
+        filter_plugin.filters()["reportsmerger"]([test_file])


### PR DESCRIPTION
## the filter plugins `reportsmerger` does 2 things:
1. merges multiple jsons into 1 file
2. updates counters/timers

The patch contains:
- code + tests + data
- documentation + usage examples under `doc/`