### PR TITLE
Move python requirements to file

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,23 +10,20 @@ RUN dnf -y install --setopt=install_weak_deps=False --setopt=tsdocs=False \
     python3-pip \
     && dnf clean all
 
-# Install ansible and ansible-lint
-RUN pip3 install --no-cache-dir \
-    ansible \
-    ansible-lint \
-    netaddr \
-    jmespath \
-    paramiko \
-    ncclient \
-    requests \
-    jira \
-    lxml \
-    junitparser
+# Copy python requirements file to eco-ci-cd folder
+COPY pip.txt .
 
-# Copy application files to eco-ci-cd folder
-COPY . .
-# Install requirements
+# Install python dependencies
+RUN pip3 install --no-cache-dir -r pip.txt
+
+# Copy galaxy requirements file to eco-ci-cd folder
+COPY requirements.yml .
+
+# Install ansible collections
+# Install galaxy requirements
 RUN ansible-galaxy collection install -r requirements.yml
+
+COPY . .
 
 # Set entrypoint to bash
 ENTRYPOINT ["/bin/bash"]

--- a/pip.txt
+++ b/pip.txt
@@ -1,0 +1,8 @@
+ansible
+ansible-lint
+jira
+jmespath
+jsonpatch
+junitparser
+ncclient
+netaddr


### PR DESCRIPTION
### changes:
- update the list of packages:
    - del: `requests`, `paramiko` (they get installed as dependencies)
    - add: `jsonpatch` (missing package)
- update Containerfile:
    - do `COPY` before pip install
    
### tests:

#### 1. ensure `pip3 freeze` changes as expected:
```bash
cmd="pip3 freeze"
for br in main requirements-file; do
    img="localhost/eco-ci-cd:br-${br}"
    git switch "${br}"
    podman build --platform linux/amd64 -t "${img}" -f Containerfile .
    podman run --platform linux/amd64 --rm -it "${img}" -c "${cmd}" > ../"pip.freeze.${br}.txt"
done

diff -u ../pip.freeze.{main,requirements-file}.txt
--- ../pip.freeze.main.txt      2025-09-05 00:08:16.698870929 +0300
+++ ../pip.freeze.requirements-file.txt 2025-09-05 00:08:17.299602169 +0300
@@ -22,6 +22,8 @@
 Jinja2==3.1.6
 jira==3.8.0
 jmespath==1.0.1
+jsonpatch==1.33
+jsonpointer==3.0.0
 jsonschema==4.25.1
 jsonschema-specifications==2025.4.1
 junitparser==4.0.2
 ```
 
 #### 2. ensure adding a line in `requirements.txt` updates a layer (modifies the layer):
 
 ```bash
br=requirements-file
img=localhost/eco-ci-cd:br-${br}-xyz"
echo "argcomplete" >> requirements.txt
podman build --platform linux/amd64 -t "${img}" -f Containerfile .
podman image inspect  localhost/eco-ci-cd:br-requirements-file  | jq -r '.[].RootFS.Layers[]' > ../layers.txt
podman image inspect  localhost/eco-ci-cd:br-requirements-file-xyz  | jq -r '.[].RootFS.Layers[]' > ../layers.xyz.txt

diff -u ../layers.txt ../layers.xyz.txt
--- ../layers.txt       2025-09-05 00:19:24.897637066 +0300
+++ ../layers.xyz.txt   2025-09-05 00:19:41.251512540 +0300
@@ -1,5 +1,5 @@
 sha256:b989f0b527ca3362fbfd6c387a16da6e8f5d56d8d850fd3562b774d8cd84e819
 sha256:bc484743fcedc50c4f13cbd85051cbefd88c96d93fb35aaf106be58f35629662
-sha256:f1b2768a10521193173269cd6ac265026d0439696f56a8311b3d04eb0886e02f
-sha256:618b07f709daacec49248d3f8ee79f3857298b58c13b1a1b95fe8687d4b72551
-sha256:4cb50120280d9f0446f95db36ebe5a626aab200453fe4a5f2c12bca93ea7e5b7
+sha256:c69646b459101f6db970162562d98b86568a749fb8a33607d6f3e259bfe04b02
+sha256:7b2df91c58cefbbdf231bb3ce89c94d106389e2454b38975d4401fb21d097dbf
+sha256:845145bdb5cc19b8afca6114bfc1abab81ec2adfce720660c70f255ab34b6002
 ```
 as expected.