### PR TITLE
update ansible-lint workflow

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,3 +6,4 @@ skip_list:
 exclude_paths:
   - "tests/dast"
   - "*collections*"
+  - ".venv"

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run ansible-lint
         uses: ansible/ansible-lint@main


### PR DESCRIPTION
- bump versions to the stable:
    -  `actions/checkout`: `v5`
    - `ansible/ansible-lint`: `v25.8.2`
- update `.ansible-lint`: ignore `.venv` (local development)
- rename the workflow file to be `pull-request.yml` (to accomodate more than ansible-lint)
