### PR TITLE
# `junit2json`: ensure missing `junit2_output_dir`

### DIFF
--- a/playbooks/roles/junit2json/tasks/convert-list.yml
+++ b/playbooks/roles/junit2json/tasks/convert-list.yml
@@ -3,6 +3,12 @@
 # tasks file for junit2json
 # task list: convert-list.yml converts XML reports to JSON
 
+- name: Ensure output directory exists
+  ansible.builtin.file:
+    path: "{{ junit2_output_dir }}"
+    state: directory
+    mode: "0755"
+
 - name: Convert XML file to JSON
   ansible.builtin.include_tasks:
     file: convert.yml


### PR DESCRIPTION
- ensure output dir `junit2_output_dir` exists
- this mostly affects only the dev cycles (in prod output=input)
