### PR TITLE
## fix `report_send` https detection

### DIFF
--- a/playbooks/roles/report_send/tasks/main.yml
+++ b/playbooks/roles/report_send/tasks/main.yml
@@ -9,7 +9,7 @@
       - ((rs_collector_auth_token | default('') | length) > 0)
         or
         ((rs_collector_auth_headers | default([]) | length) > 0)
-      - rs_collector_url | regex_search('^https://')
+      - rs_collector_url is match('^https://')
       - rs_collector_url | length > 0
       - rs_combined_event_path | length > 0
     fail_msg: "One or more required conditions are not met"


### PR DESCRIPTION
Improve https URL detector:
  - was: `| regex_search()` - could return `none`
  - now: ` is match()` - is always boolean