### PR TITLE
## Adding splunk/etc. reporting playbook, its inventory and e2e test playbooks

### DIFF
--- a/inventories/reporting/report-send.yml
+++ b/inventories/reporting/report-send.yml
@@ -1,0 +1,5 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+      ansible_python_interpreter: "{{ ansible_playbook_python }}"

--- a/playbooks/reporting/report-send.yml
+++ b/playbooks/reporting/report-send.yml
@@ -1,0 +1,25 @@
+---
+- name: Push CI JUnit XML report data to collector
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Convert JUnit reports to JSON
+      ansible.builtin.include_role:
+        name: junit2json
+      tags:
+        - junit2json
+    - name: Detect metadata
+      ansible.builtin.include_role:
+        name: report_metadata_gen
+      tags:
+        - report_metadata_gen
+    - name: Combine tests and metadata
+      ansible.builtin.include_role:
+        name: report_combine
+      tags:
+        - report_combine
+    - name: Upload reports to collector (splunk)
+      ansible.builtin.include_role:
+        name: report_send
+      tags:
+        - report_send

--- a/playbooks/reporting/test-report-send.yml
+++ b/playbooks/reporting/test-report-send.yml
@@ -1,0 +1,20 @@
+---
+- name: Test activities before main report processing
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: Run pre-test activities
+      ansible.builtin.debug:
+        msg: "Pre-test actions"
+    - name: Assert rs_collector_url is set
+      ansible.builtin.assert:
+        that:
+          - rs_collector_url | default('') | length > 0
+        fail_msg: "rs_collector_url is not set"
+    - name: Assert rs_collector_auth_token is set
+      ansible.builtin.assert:
+        that:
+          - rs_collector_auth_token | default('') | length > 0
+        fail_msg: "rs_collector_auth_token is not set"
+- name: Import the main report send playbook
+  ansible.builtin.import_playbook: report-send.yml

--- a/playbooks/reporting/test-time-conversion.yml
+++ b/playbooks/reporting/test-time-conversion.yml
@@ -1,0 +1,9 @@
+---
+- name: Test time conversion from datetime to unix timestamp
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  tasks:
+    - name: Convert JUnit XML to JSON
+      ansible.builtin.include_role:
+        name: junit2json


### PR DESCRIPTION
1. Reporting Playbook: [`report_send.yml`](playbooks/reporting/report-send.yml)
    - variables are under `playbooks/reporting/fixtures/<component>/report-send.yml`
2. Tests:
    - Test the Reporting Playbook: [`test_report_send.yml`](playbooks/reporting/test_report_send.yml) - use actual reporting playbook to prevent divergence - prints a bit more than reporting for debugging
    - Test time conversions: [`test_time_conversion.yml`](playbooks/reporting/test_time_conversion.yml)
3. The inventory [`report-send.yml`](inventories/reporting/report-send.yml)