### PR TITLE
## add support to override `time`

### DIFF
--- a/playbooks/roles/report_combine/README.md
+++ b/playbooks/roles/report_combine/README.md
@@ -50,7 +50,13 @@ including Splunk HEC format and generic formats.
   - **Type**: str
   - **Default**: {{ ansible_hostname }}
   - **Description**: Event source identifier
-  
+
+- **rc_event_time**
+  - **Required**: False
+  - **Type**: str
+  - **Default**: `""`
+  - **Description**: Event source identifier
+
 - **rc_event_host**
   - **Required**: False
   - **Type**: str
@@ -73,15 +79,16 @@ including Splunk HEC format and generic formats.
 
 | Var          | Type         | Value       |Required    | Title       |
 |--------------|--------------|-------------|-------------|-------------|
-| [rc_report_path](defaults/main.yml#L6)   | str   | `` |    n/a  |  n/a |
-| [rc_metadata_path](defaults/main.yml#L7)   | str   | `` |    n/a  |  n/a |
-| [rc_combined_event_path](defaults/main.yml#L10)   | str   | `{{ playbook_dir }}/output/combined-event.json` |    n/a  |  n/a |
-| [rc_event_source](defaults/main.yml#L13)   | str   | `{{ rc_meta_data.ci.url ¦ default(ansible_hostname) }}` |    n/a  |  n/a |
-| [rc_event_host](defaults/main.yml#L14)   | str   | `{{ splunk_url ¦ default(ansible_hostname) }}` |    n/a  |  n/a |
+| [rc_report_path](defaults/main.yml#L6)   | str   | `` |    True  |  Path to the test report JSON file |
+| [rc_metadata_path](defaults/main.yml#L7)   | str   | `` |    True  |  Path to the metadata JSON file |
+| [rc_combined_event_path](defaults/main.yml#L10)   | str   | `{{ playbook_dir }}/output/combined-event.json` |    False  |  Path where to save the combined event JSON file |
+| [rc_event_time](defaults/main.yml#L16)   | str   | `` |    False  |  Event time in epoch float format as string |
+| [rc_event_source](defaults/main.yml#L13)   | str   | `{{ ansible_hostname }}` |    False  |  Event source identifier |
+| [rc_event_host](defaults/main.yml#L14)   | str   | `{{ ansible_hostname }}` |    False  |  Event host identifier |
 | [rc_event_sourcetype](defaults/main.yml#L15)   | str   | `_json` |    n/a  |  n/a |
-| [rc_collector_format](defaults/main.yml#L18)   | str   | `splunk` |    n/a  |  n/a |
+| [rc_collector_format](defaults/main.yml#L18)   | str   | `splunk` |    False  |  Format for the combined event structure |
 | [rc_supported_formats](defaults/main.yml#L19)   | list   | `['splunk', 'generic']` |    n/a  |  n/a |
-| [rc_debug](defaults/main.yml#L24)   | bool   | `False` |    n/a  |  n/a |
+| [rc_debug](defaults/main.yml#L24)   | bool   | `False` |    False  |  Enable debug output |
 | [rc_test_data](defaults/main.yml#L27)   | dict   | `{}` |    n/a  |  n/a |
 | [rc_meta_data](defaults/main.yml#L28)   | dict   | `{}` |    n/a  |  n/a |
 | [rc_combined_event](defaults/main.yml#L29)   | dict   | `{}` |    n/a  |  n/a |
@@ -92,155 +99,49 @@ including Splunk HEC format and generic formats.
 
 | Name | Module | Has Conditions |
 | ---- | ------ | --------- |
-| Gathering file stats for {{ _rc_file_path }} | ansible.builtin.stat | False |
-| Validating file requirements for {{ _rc_file_path }} | ansible.builtin.assert | False |
+| Gathering file stats for `{{ _rc_file_path }}` | `ansible.builtin.stat` | False |
+| Validating file requirements for `{{ _rc_file_path }}` | `ansible.builtin.assert` | False |
 
 #### File: `tasks/read-file.yml`
 
 | Name | Module | Has Conditions |
 | ---- | ------ | --------- |
-| Validate the file exists, readable and non-empty | ansible.builtin.include_tasks | False |
-| Read JSON file {{ _rc_file_item.path }} | ansible.builtin.slurp | False |
-| Parse data as JSON from file {{ _rc_file_item.path }} | ansible.builtin.set_fact | False |
-| Verify the data is not empty (mandatory={{ _rc_file_item.mandatory ¦ default(false) ¦ string }}) | ansible.builtin.assert | True |
-| Print user note | ansible.builtin.debug | True |
-| Print {{ _rc_file_item.name }} (vebosity>=3) | ansible.builtin.debug | False |
+| Validate the file exists, readable and non-empty | `ansible.builtin.include_tasks` | False |
+| Read JSON file {{ _rc_file_item.path }} | `ansible.builtin.slurp` | False |
+| Parse data as JSON from file {{ _rc_file_item.path }} | `ansible.builtin.set_fact` | False |
+| Verify the data is not empty (mandatory={{ _rc_file_item.mandatory ¦ default(false) ¦ string }}) | `ansible.builtin.assert` | True |
+| Print user note | `ansible.builtin.debug` | True |
+| Print {{ _rc_file_item.name }} (verbosity>=3) | `ansible.builtin.debug` | False |
 
 #### File: `tasks/main.yml`
 
 | Name | Module | Has Conditions |
 | ---- | ------ | --------- |
-| Validate required parameters | ansible.builtin.assert | False |
-| Read input files | ansible.builtin.include_tasks | False |
-| Combine data using format-specific logic | ansible.builtin.include_tasks | False |
-| Print combined event structure | ansible.builtin.debug | True |
-| Ensure output directory exists | ansible.builtin.file | True |
-| Write combined event to output file | ansible.builtin.copy | True |
+| Validate required parameters | `ansible.builtin.assert` | False |
+| Read input files | `ansible.builtin.include_tasks` | False |
+| Combine data using format-specific logic | `ansible.builtin.include_tasks` | False |
+| Print combined event structure | `ansible.builtin.debug` | True |
+| Ensure output directory exists | `ansible.builtin.file` | True |
+| Write combined event to output file | `ansible.builtin.copy` | True |
 
 #### File: `tasks/formats/splunk.yml`
 
 | Name | Module | Has Conditions |
 | ---- | ------ | --------- |
-| Create basic event structure | ansible.builtin.set_fact | False |
-| Create Splunk-specific event payload | ansible.builtin.set_fact | False |
-| Add optional timestamp if available in metadata | ansible.builtin.set_fact | True |
-| Print Splunk event structure | ansible.builtin.debug | True |
+| Create basic event structure | `ansible.builtin.set_fact` | False |
+| Set default metadata based event time | `ansible.builtin.set_fact` | True |
+| Generate fallback event time if metadata does not have it | `ansible.builtin.set_fact` | True |
+| Ensure rc_event_time can be converted to a float | `ansible.builtin.assert` | False |
+| Create Splunk-specific event payload | `ansible.builtin.set_fact` | False |
+| Print Splunk event structure | `ansible.builtin.debug` | True |
 
 #### File: `tasks/formats/generic.yml`
 
 | Name | Module | Has Conditions |
 | ---- | ------ | --------- |
-| Create generic event structure | ansible.builtin.set_fact | False |
-| Add optional timestamp if available in metadata | ansible.builtin.set_fact | True |
-| Print generic event structure | ansible.builtin.debug | True |
-
-## Task Flow Graphs
-
-### Graph for `validate-file.yml`
-
-```mermaid
-flowchart TD
-Start
-classDef block stroke:#3498db,stroke-width:2px;
-classDef task stroke:#4b76bb,stroke-width:2px;
-classDef includeTasks stroke:#16a085,stroke-width:2px;
-classDef importTasks stroke:#34495e,stroke-width:2px;
-classDef includeRole stroke:#2980b9,stroke-width:2px;
-classDef importRole stroke:#699ba7,stroke-width:2px;
-classDef includeVars stroke:#8e44ad,stroke-width:2px;
-classDef rescue stroke:#665352,stroke-width:2px;
-
-  Start-->|Task| Gathering_file_stats_for__rc_file_path0[gathering file stats for  rc file path]:::task
-  Gathering_file_stats_for__rc_file_path0-->|Task| Validating_file_requirements_for__rc_file_path1[validating file requirements for  rc file path]:::task
-  Validating_file_requirements_for__rc_file_path1-->End
-```
-
-### Graph for `read-file.yml`
-
-```mermaid
-flowchart TD
-Start
-classDef block stroke:#3498db,stroke-width:2px;
-classDef task stroke:#4b76bb,stroke-width:2px;
-classDef includeTasks stroke:#16a085,stroke-width:2px;
-classDef importTasks stroke:#34495e,stroke-width:2px;
-classDef includeRole stroke:#2980b9,stroke-width:2px;
-classDef importRole stroke:#699ba7,stroke-width:2px;
-classDef includeVars stroke:#8e44ad,stroke-width:2px;
-classDef rescue stroke:#665352,stroke-width:2px;
-
-  Start-->|Include task| validate_file_yml0[validate the file exists  readable and non empty<br>include_task: validate file yml]:::includeTasks
-  validate_file_yml0-->|Task| Read_JSON_file_____rc_file_item_path___1[read json file     rc file item path   ]:::task
-  Read_JSON_file_____rc_file_item_path___1-->|Task| Parse_data_as_JSON_from_file_____rc_file_item_path___2[parse data as json from file     rc file item path<br>  ]:::task
-  Parse_data_as_JSON_from_file_____rc_file_item_path___2-->|Task| Verify_the_data_is_not_empty__mandatory_____rc_file_item_mandatory___default_false____string____3[verify the data is not empty  mandatory     rc<br>file item mandatory   default false    string    <br>When: **rc file item mandatory is defined and  rc file<br>item mandatory   default false**]:::task
-  Verify_the_data_is_not_empty__mandatory_____rc_file_item_mandatory___default_false____string____3-->|Task| Print_user_note4[print user note<br>When: **not   rc file item mandatory   default false   and<br>vars  rc file item name    length    0**]:::task
-  Print_user_note4-->|Task| Print_____rc_file_item_name_____vebosity__3_5[print     rc file item name     vebosity  3 ]:::task
-  Print_____rc_file_item_name_____vebosity__3_5-->End
-```
-
-### Graph for `main.yml`
-
-```mermaid
-flowchart TD
-Start
-classDef block stroke:#3498db,stroke-width:2px;
-classDef task stroke:#4b76bb,stroke-width:2px;
-classDef includeTasks stroke:#16a085,stroke-width:2px;
-classDef importTasks stroke:#34495e,stroke-width:2px;
-classDef includeRole stroke:#2980b9,stroke-width:2px;
-classDef importRole stroke:#699ba7,stroke-width:2px;
-classDef includeVars stroke:#8e44ad,stroke-width:2px;
-classDef rescue stroke:#665352,stroke-width:2px;
-
-  Start-->|Task| Validate_required_parameters0[validate required parameters]:::task
-  Validate_required_parameters0-->|Include task| read_file_yml1[read input files<br>include_task: read file yml]:::includeTasks
-  read_file_yml1-->|Include task| formats____rc_collector_format____yml2[combine data using format specific logic<br>include_task: formats    rc collector format    yml]:::includeTasks
-  formats____rc_collector_format____yml2-->|Task| Print_combined_event_structure3[print combined event structure<br>When: **rc debug**]:::task
-  Print_combined_event_structure3-->|Task| Ensure_output_directory_exists4[ensure output directory exists<br>When: **rc combined event path   length   0 and rc<br>combined event path   dirname   length   1**]:::task
-  Ensure_output_directory_exists4-->|Task| Write_combined_event_to_output_file5[write combined event to output file<br>When: **rc combined event path   length   0**]:::task
-  Write_combined_event_to_output_file5-->End
-```
-
-### Graph for `formats/splunk.yml`
-
-```mermaid
-flowchart TD
-Start
-classDef block stroke:#3498db,stroke-width:2px;
-classDef task stroke:#4b76bb,stroke-width:2px;
-classDef includeTasks stroke:#16a085,stroke-width:2px;
-classDef importTasks stroke:#34495e,stroke-width:2px;
-classDef includeRole stroke:#2980b9,stroke-width:2px;
-classDef importRole stroke:#699ba7,stroke-width:2px;
-classDef includeVars stroke:#8e44ad,stroke-width:2px;
-classDef rescue stroke:#665352,stroke-width:2px;
-
-  Start-->|Task| Create_basic_event_structure0[create basic event structure]:::task
-  Create_basic_event_structure0-->|Task| Create_Splunk_specific_event_payload1[create splunk specific event payload]:::task
-  Create_Splunk_specific_event_payload1-->|Task| Add_optional_timestamp_if_available_in_metadata2[add optional timestamp if available in metadata<br>When: **rc meta data job is defined and rc meta data job<br>created at is defined and rc meta data job created<br>at   length   0**]:::task
-  Add_optional_timestamp_if_available_in_metadata2-->|Task| Print_Splunk_event_structure3[print splunk event structure<br>When: **rc debug**]:::task
-  Print_Splunk_event_structure3-->End
-```
-
-### Graph for `formats/generic.yml`
-
-```mermaid
-flowchart TD
-Start
-classDef block stroke:#3498db,stroke-width:2px;
-classDef task stroke:#4b76bb,stroke-width:2px;
-classDef includeTasks stroke:#16a085,stroke-width:2px;
-classDef importTasks stroke:#34495e,stroke-width:2px;
-classDef includeRole stroke:#2980b9,stroke-width:2px;
-classDef importRole stroke:#699ba7,stroke-width:2px;
-classDef includeVars stroke:#8e44ad,stroke-width:2px;
-classDef rescue stroke:#665352,stroke-width:2px;
-
-  Start-->|Task| Create_generic_event_structure0[create generic event structure]:::task
-  Create_generic_event_structure0-->|Task| Add_optional_timestamp_if_available_in_metadata1[add optional timestamp if available in metadata<br>When: **rc meta data job is defined and rc meta data job<br>created at is defined and rc meta data job created<br>at   length   0**]:::task
-  Add_optional_timestamp_if_available_in_metadata1-->|Task| Print_generic_event_structure2[print generic event structure<br>When: **rc debug**]:::task
-  Print_generic_event_structure2-->End
-```
+| Create generic event structure | `ansible.builtin.set_fact` | False |
+| Add optional timestamp if available in metadata | `ansible.builtin.set_fact` | True |
+| Print generic event structure | `ansible.builtin.debug` | True |
 
 ## Author Information
 

--- a/playbooks/roles/report_combine/defaults/main.yml
+++ b/playbooks/roles/report_combine/defaults/main.yml
@@ -13,6 +13,7 @@ rc_combined_event_path: "{{ playbook_dir }}/output/combined-event.json"
 rc_event_source: "{{ ansible_hostname }}"
 rc_event_host: "{{ ansible_hostname }}"
 rc_event_sourcetype: "_json"
+rc_event_time: ""
 
 # Collector-specific formatting
 rc_collector_format: "splunk"

--- a/playbooks/roles/report_combine/meta/argument_specs.yml
+++ b/playbooks/roles/report_combine/meta/argument_specs.yml
@@ -29,6 +29,11 @@ argument_specs:
         required: false
         default: "splunk"
         choices: ["splunk", "generic"]
+      rc_event_time:
+        description: Event time in epoch float format as string
+        type: str
+        required: false
+        default: ""
       rc_event_source:
         description: Event source identifier
         type: str

--- a/playbooks/roles/report_combine/tasks/formats/splunk.yml
+++ b/playbooks/roles/report_combine/tasks/formats/splunk.yml
@@ -8,6 +8,29 @@
       test: "{{ rc_test_data }}"
       metadata: "{{ rc_meta_data }}"
 
+- name: Set default metadata based event time
+  ansible.builtin.set_fact:
+    rc_event_time: >-
+      {{
+        (((rc_event.metadata.job.created_at.replace('Z', '+00:00') | to_datetime).timestamp() * 1000) | int / 1000.0) | string
+      }}
+  when:
+    - rc_event_time | default('') | length == 0
+    - rc_event.metadata.job is defined
+    - rc_event.metadata.job.created_at | default('') | length > 0
+
+- name: Generate fallback event time if metadata does not have it
+  ansible.builtin.set_fact:
+    rc_event_time: "{{ ansible_date_time.epoch }}.{{ '%03d' | format((ansible_date_time.microsecond | int / 1000) | int) }}"
+  when:
+    - rc_event_time | default('') | length == 0
+
+- name: Ensure rc_event_time can be converted to a float
+  ansible.builtin.assert:
+    that:
+      - rc_event_time | float is defined
+    fail_msg: "Event time {{ rc_event_time }} cannot be converted to a float"
+
 - name: Create Splunk-specific event payload
   ansible.builtin.set_fact:
     rc_combined_event:
@@ -15,20 +38,7 @@
       "event": "{{ rc_event }}"
       "host": "{{ rc_event_host }}"
       "sourcetype": "{{ rc_event_sourcetype }}"
-
-- name: Add optional timestamp if available in metadata
-  ansible.builtin.set_fact:
-    rc_combined_event: "{{ rc_combined_event | combine({'time': rc_event_time}) }}"
-  vars:
-    rc_event_time: >-
-      {{
-        (rc_meta_data.job.created_at | to_datetime('%Y-%m-%dT%H:%M:%S.%f')).strftime('%s') | int
-          if (rc_meta_data.job.created_at is defined) else omit
-      }}
-  when:
-    - rc_meta_data.job is defined
-    - rc_meta_data.job.created_at is defined
-    - rc_meta_data.job.created_at | length > 0
+      "time": "{{ rc_event_time | float }}"
 
 - name: Print Splunk event structure
   ansible.builtin.debug:


### PR DESCRIPTION
The dashboard testing requires data to test queries before the data producing code has been deployed and enabled This raises the need to be able to upload synthetic/crafted data. For this we need to be able to set event time

This patch implements this feature:
    - allows override via `rc_event_time`
    - calculates default from event `metadata`
    - implements a fallback (based on `ansible_date_time`)