### PR TITLE
Cast value to boolean and fix certificate Prow format issue

### DIFF
--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -212,7 +212,7 @@
 
     - name: Set up IPv4-only cluster network configuration
       delegate_to: bastion
-      when: ipv4_only
+      when: ipv4_only | bool
       ansible.builtin.set_fact:
         api_vips: >-
           {{ api_vips | select('match', '^[0-9.]+$') | list }}
@@ -224,7 +224,7 @@
 
     - name: Set up IPv6-only cluster network configuration
       delegate_to: bastion
-      when: ipv6_only
+      when: ipv6_only | bool
       ansible.builtin.set_fact:
         api_vips: >-
           {{ api_vips | reject('match', '^[0-9.]+$') | list }}
@@ -392,7 +392,7 @@
           }}
 
     - name: Remove IPv6 section from each interface
-      when: ipv4_only
+      when: ipv4_only | bool
       delegate_to: bastion
       ansible.builtin.set_fact:
         network_config: >-
@@ -415,7 +415,7 @@
           }}
 
     - name: Remove IPv4 configuration from each interface (IPv6‑only cluster)
-      when: ipv6_only
+      when: ipv6_only | bool
       delegate_to: bastion
       ansible.builtin.set_fact:
         network_config: >-
@@ -472,7 +472,7 @@
         state: absent
 
     - name: Generate deployment manifests for OpenShift installation
-      when: disconnected | bool is false
+      when: (disconnected | bool) is false
       vars:
         single_node_openshift_enabled: true
       ansible.builtin.import_role:

--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -478,17 +478,28 @@
       ansible.builtin.import_role:
         name: redhatci.ocp.generate_manifests
 
-    - name: Generate deployment manifests for disconnected OpenShift installation
-      vars:
-        single_node_openshift_enabled: true
-        use_local_mirror_registry: true
-        mirror_registry: "disconnected.registry.local:5000"
-        mirror_certificate: "{{ disconnected_registry_cert }}"
-        ocp_registry_namespace: ocp4
-        ocp_registry_image: openshift
+    - name: Configure trusted CA for internal registry (SNO)
       when: disconnected | bool
-      ansible.builtin.import_role:
-        name: redhatci.ocp.generate_manifests
+      block:
+        # In Prow environment, the disconnected registry certificate is in raw string format, we need to re-format it.
+        # Based on the env variable SHARED_DIR, we can determine if we are in Prow environment.
+        - name: Format disconnected registry certificate if needed
+          when: lookup('env', 'SHARED_DIR') | length > 0
+          ansible.builtin.set_fact:
+            disconnected_registry_cert_formatted: "-----BEGIN CERTIFICATE-----\n
+              {{ disconnected_registry_cert.strip('-----BEGIN CERTIFICATE-----').
+              strip('-----END CERTIFICATE-----') | regex_replace('\\s+', '\n')}}\n-----END CERTIFICATE-----"
+
+        - name: Generate deployment manifests for disconnected OpenShift installation
+          vars:
+            single_node_openshift_enabled: true
+            use_local_mirror_registry: true
+            mirror_registry: "disconnected.registry.local:5000"
+            mirror_certificate: "{{ disconnected_registry_cert_formatted | default(disconnected_registry_cert) }}"
+            ocp_registry_namespace: ocp4
+            ocp_registry_image: openshift
+          ansible.builtin.import_role:
+            name: redhatci.ocp.generate_manifests
 
     - name: Generate boot ISO for agent-based installer
       vars:


### PR DESCRIPTION
Trying to run:

```
ansible-playbook -i inventories/ocp-deployment/build-inventory.py playbooks/deploy-ocp-sno.yml -e release=4.16 -e cluster_name=hlxcl15-sno -e ocp_version_facts_release_type=stable -e ocp_version_release_age_max_days=15 -e disconnected=false -e ipv4_only=true -e ipv6_only=false -vvv
```

Doesn't skip:
```
    - name: Set up IPv6-only cluster network configuration
      delegate_to: bastion
      when: ipv6_only | bool
      ansible.builtin.set_fact:
      . . .
```
Logs:
```
TASK [Set up IPv6-only cluster network configuration] ******************************************************************************************************************************************************************************************************
task path: /eco-ci-cd/playbooks/deploy-ocp-sno.yml:230
fatal: [bastion]: FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: ansible.parsing.yaml.objects.AnsibleUnicode object has no element 0. ansible.parsing.yaml.objects.AnsibleUnicode object has no element 0\n\nThe error appears to be in '/eco-ci-cd/playbooks/deploy-ocp-sno.yml': line 230, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Set up IPv6-only cluster network configuration\n      ^ here\n"
}
```
