### PR TITLE
Fix hypervisor CA certificate installation path

### DIFF
--- a/playbooks/infra/deploy-bm-hypervisor.yml
+++ b/playbooks/infra/deploy-bm-hypervisor.yml
@@ -363,7 +363,7 @@
         - name: Download CA certificate to pki directory
           ansible.builtin.get_url:
             url: "{{ ca_update_link }}"
-            dest: /etc/pki/tls/certs/certificate.crt
+            dest: /etc/pki/ca-trust/source/anchors/certificate.crt
             mode: '0644'
 
         - name: Update certificate


### PR DESCRIPTION
The hypervisor playbook was saving the CA certificate to the wrong directory (/etc/pki/tls/certs/), which is the output directory for the trust bundle, not the input directory for custom CA certificates.

This caused the CA certificate to be downloaded but not processed by update-ca-trust, resulting in SSL certificate verification failures when accessing internal Red Hat services like gitlab.cee.redhat.com.

Changed destination path from:
  /etc/pki/tls/certs/certificate.crt
To:
  /etc/pki/ca-trust/source/anchors/certificate.crt

This matches the bastion playbook (deploy-vm-bastion-libvirt.yml) which uses the correct path and successfully trusts the internal CA.

Fixes: SSL certificate problem: self-signed certificate in certificate chain