### PR TITLE
Add --remove-signatures flag to oc-mirror for certified operators

### DIFF
--- a/playbooks/roles/ocp_operator_mirror/tasks/mirror_operators_prod.yaml
+++ b/playbooks/roles/ocp_operator_mirror/tasks/mirror_operators_prod.yaml
@@ -147,7 +147,7 @@
     -c "{{ ocp_operator_mirror_image_set_configuration_path }}"
     --workspace file:///{{ ocp_operator_mirror_workspace_path }}
     docker://{{ ocp_operator_mirror_registry_url }}/{{ ocp_operator_mirror_folder }}
-    --ignore-release-signature --v2
+    --ignore-release-signature --remove-signatures --v2
 
 - name: Show oc-mirror result
   ansible.builtin.debug:


### PR DESCRIPTION
Fixes signature verification failures when mirroring certified operator
images (e.g., Intel sriov-fec) that don't publish .sig manifests.
oc-mirror 4.21 appears to have stricter signature checking than 4.20,
requiring the --remove-signatures flag to skip verification for images
without published signatures.