### PR TITLE
Update the operator namespace for insights

### DIFF
--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -587,7 +587,7 @@
               kind: ConfigMap
               metadata:
                 name: insights-config
-                namespace: openshift-config
+                namespace: openshift-insights
               data:
                 config.yaml: |
                   dataReporting:


### PR DESCRIPTION
Fixes a problem due to the namespace for the Insights operator changing from 4.12 onwards.