### PR TITLE
Wait for the spoke cluster to be reachable before proceeding

### DIFF
--- a/playbooks/deploy-ocp-sno-day2-worker.yml
+++ b/playbooks/deploy-ocp-sno-day2-worker.yml
@@ -92,6 +92,17 @@
             dest: "{{ spoke_kubeconfig }}"
             mode: '0600'
 
+        - name: Wait for the spoke cluster API to become reachable
+          kubernetes.core.k8s_info:
+            api_version: v1
+            kind: Namespace
+            name: default
+            kubeconfig: "{{ spoke_kubeconfig }}"
+          register: spoke_api_check
+          until: spoke_api_check is success
+          retries: 30
+          delay: 30
+
         - name: Get the configs from spoke cluster for each operator
           kubernetes.core.k8s_info:
             api_version: "{{ item.api_version }}"


### PR DESCRIPTION
Fixes a race condition where the playbook would crash if the spoke cluster API wasn't stabilized before querying the cluster operator configs.