### PR TITLE
Add nmap-ncat for cnf-gotests

### DIFF
--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -400,6 +400,7 @@
           - make
           - pip
           - skopeo
+          - nmap-ncat   # Required by cnf-gotests
         state: present
 
     - name: Download GO archive


### PR DESCRIPTION
This adds a dependency required for executing the reboot feature of cnf-gotests.