### PR TITLE
Add nmap-ncat for cnf-gotests

### DIFF
--- a/playbooks/cnf/deploy-run-downstream-tests-script.yaml
+++ b/playbooks/cnf/deploy-run-downstream-tests-script.yaml
@@ -67,6 +67,12 @@
           - metallb_vlans is defined
           - switch_interfaces is defined
 
+    - name: Install required packages
+      become: true
+      ansible.builtin.dnf:
+        name:
+          - nmap-ncat
+
     - name: Gather cluster network information
       register: cluster_info
       environment:


### PR DESCRIPTION
Add a dependency required by the reboot feature of cnf-gotests