### PR TITLE
feat(infra): Add container image mirroring infrastructure

### DIFF
--- a/playbooks/roles/container_image_mirror/README.md
+++ b/playbooks/roles/container_image_mirror/README.md
@@ -1,0 +1,309 @@
+# Container Image Mirror Ansible Role
+
+## Disclaimer
+This role is provided as-is, without guarantees of support or maintenance.
+Use at your own discretion.
+
+## Overview
+The `container_image_mirror` role provides generic container image mirroring and removal capabilities for internal registries. It uses `skopeo` to:
+- **Mirror** container images from source registries to a target internal registry
+- **Remove** container images from an internal registry
+
+This role is designed to work with any container registry and supports both connected and disconnected (air-gapped) environments.
+
+## Features
+- Generic image mirroring using `skopeo copy`
+- Image removal from registry storage
+- Pull secret support for private registries
+- Configurable TLS verification
+- Detailed success/failure reporting with summary
+- Idempotent operations with existence checks
+- Continues mirroring all images even if some fail
+- Per-image success/failure tracking
+
+## Requirements
+- Ansible 2.9+
+- Tools available on the target host:
+  - `skopeo` (for mirroring operations)
+- For removal operations:
+  - `sudo` access to registry storage path
+- Target registry must be reachable
+- Pull secrets for source registries (if private)
+
+## Role Variables
+
+### Required Variables
+
+- **`container_image_mirror_images`** (list): List of image mappings
+  - For mirror operation: `[{"source": "quay.io/org/image:tag", "dest": "namespace/image:tag"}]`
+  - For remove operation: `[{"dest": "namespace/image:tag"}]`
+  - No default (must be provided)
+
+### Optional Variables
+
+- **`container_image_mirror_operation`** (string): Operation mode
+  - Values: `mirror` or `remove`
+  - Default: `mirror`
+
+- **`container_image_mirror_registry_host`** (string): Target registry hostname
+  - Default: `{{ ansible_fqdn }}`
+
+- **`container_image_mirror_registry_port`** (int): Target registry port
+  - Default: `5000`
+
+- **`container_image_mirror_registry_namespace`** (string): Namespace prefix for destination images
+  - Default: `""` (empty, no prefix)
+  - Example: `ran-test/` would prefix all destination images
+
+- **`container_image_mirror_dest_tls_verify`** (bool): Verify TLS for destination registry
+  - Default: `false`
+
+- **`container_image_mirror_use_pull_secret`** (bool): Enable pull secret file authentication
+  - Default: `false`
+  - When `false`: skopeo uses system authentication from `/etc/containers/auth.json`
+  - When `true`: skopeo uses pull secret file via `--authfile` parameter
+
+- **`container_image_mirror_pull_secret_string`** (string): Base64-encoded pull secret JSON
+  - Default: `""` (empty, uses existing auth)
+  - Format: Base64-encoded Docker config JSON
+  - Only used when `container_image_mirror_use_pull_secret=true`
+
+- **`container_image_mirror_pull_secret_path`** (string): Path to store pull secret
+  - Default: `/tmp/.pull-secret-mirror.json`
+  - Only used when `container_image_mirror_use_pull_secret=true`
+
+- **`container_image_mirror_registry_data_path`** (string): Registry storage path (for removal)
+  - Default: `/home/telcov10n/registry/data/docker/registry/v2/repositories`
+
+## Dependencies
+None.
+
+## Authentication Methods
+
+The role supports two authentication methods:
+
+### System Authentication (Recommended)
+
+When `use_pull_secret=false` (default), skopeo uses system authentication from `/etc/containers/auth.json`. This is the recommended approach when:
+- Source registries are public
+- Authentication has been configured beforehand (e.g., via `podman login` or `authWithQuay()` in Jenkins)
+- Both source and destination credentials are in the system auth file
+
+### Pull Secret File Authentication
+
+When `use_pull_secret=true`, skopeo uses a dedicated pull secret file via the `--authfile` parameter. Use this when:
+- You need to use specific credentials different from system auth
+- Working with private registries requiring explicit authentication
+- Credentials should not persist in system auth
+
+**Important**: When using pull secrets, the content is never logged and the file is automatically cleaned up after use.
+
+## Example Playbooks
+
+### Mirror Images with System Authentication (Recommended)
+
+```yaml
+---
+- name: Mirror RAN test images to internal registry
+  hosts: bastion
+  gather_facts: true
+  roles:
+    - role: container_image_mirror
+      vars:
+        container_image_mirror_operation: mirror
+        container_image_mirror_registry_host: disconnected.registry.local
+        container_image_mirror_registry_port: 5000
+        container_image_mirror_registry_namespace: ran-test/
+        container_image_mirror_images:
+          - source: quay.io/telcov10n-ci/oslat:latest
+            dest: oslat:latest
+          - source: quay.io/telcov10n-ci/cyclictest:latest
+            dest: cyclictest:latest
+          - source: quay.io/telcov10n-ci/cnf-tests:4.8
+            dest: cnf-tests:4.8
+```
+
+### Mirror Images with Pull Secret
+
+```yaml
+---
+- name: Mirror private images to internal registry
+  hosts: bastion
+  gather_facts: true
+  roles:
+    - role: container_image_mirror
+      vars:
+        container_image_mirror_operation: mirror
+        container_image_mirror_registry_host: registry.example.com
+        container_image_mirror_use_pull_secret: true
+        container_image_mirror_pull_secret_string: "{{ pull_secret }}"
+        container_image_mirror_images:
+          - source: quay.io/private-org/image:tag
+            dest: namespace/image:tag
+```
+
+### Remove Images Example
+
+```yaml
+---
+- name: Remove old RAN test images from internal registry
+  hosts: bastion
+  gather_facts: true
+  roles:
+    - role: container_image_mirror
+      vars:
+        container_image_mirror_operation: remove
+        container_image_mirror_registry_namespace: ran-test/
+        container_image_mirror_images:
+          - dest: oslat:old-version
+          - dest: cyclictest:deprecated
+```
+
+## Usage
+
+### Via Playbook
+
+Create a playbook that includes the role:
+
+```yaml
+---
+- name: Mirror container images
+  hosts: bastion
+  gather_facts: true
+  vars:
+    images_to_mirror:
+      - source: quay.io/org/app:v1.0
+        dest: apps/app:v1.0
+  roles:
+    - role: container_image_mirror
+      vars:
+        container_image_mirror_operation: mirror
+        container_image_mirror_images: "{{ images_to_mirror }}"
+```
+
+### Command Line
+
+```bash
+ansible-playbook mirror-images-playbook.yml \
+  -i inventories/ocp-deployment/build-inventory.py \
+  --extra-vars "container_image_mirror_pull_secret_string=$(cat ~/.docker/config.json | base64 -w0)"
+```
+
+## Output Examples
+
+### Successful Mirror
+
+```
+TASK [container_image_mirror : Display detailed mirror results]
+ok: [bastion] => {
+    "msg": [
+        "==========================================",
+        "MIRROR SUMMARY",
+        "==========================================",
+        "Total images: 3",
+        "Successfully mirrored: 3",
+        "Failed: 0",
+        "",
+        "SUCCESSFUL:",
+        "  ✓ oslat:latest",
+        "  ✓ cyclictest:latest",
+        "  ✓ cnf-tests:4.8",
+        "",
+        "FAILED:",
+        "  (none)",
+        "=========================================="
+    ]
+}
+```
+
+### Partial Failure
+
+```
+TASK [container_image_mirror : Display detailed mirror results]
+ok: [bastion] => {
+    "msg": [
+        "==========================================",
+        "MIRROR SUMMARY",
+        "==========================================",
+        "Total images: 3",
+        "Successfully mirrored: 2",
+        "Failed: 1",
+        "",
+        "SUCCESSFUL:",
+        "  ✓ oslat:latest",
+        "  ✓ cyclictest:latest",
+        "",
+        "FAILED:",
+        "  ✗ cnf-tests:4.8",
+        "=========================================="
+    ]
+}
+
+TASK [container_image_mirror : Fail if any images failed to mirror]
+fatal: [bastion]: FAILED! => {
+    "msg": "1 image(s) failed to mirror. See summary above for details."
+}
+```
+
+## Use Cases
+
+### Telco RAN Test Image Mirroring
+Mirror test images from quay.io to bastion registries for spoke cluster testing:
+```yaml
+container_image_mirror_images:
+  - {source: "quay.io/telcov10n-ci/oslat:latest", dest: "ran-test/oslat:latest"}
+  - {source: "quay.io/telcov10n-ci/cyclictest:latest", dest: "ran-test/cyclictest:latest"}
+  - {source: "quay.io/telcov10n-ci/stress-ng:latest", dest: "ran-test/stress-ng:latest"}
+```
+
+### Disconnected Environment Preparation
+Mirror images to internal registry before deploying in air-gapped environment:
+```yaml
+container_image_mirror_operation: mirror
+container_image_mirror_registry_host: registry.internal.corp
+container_image_mirror_images:
+  - {source: "quay.io/app/image:v1", dest: "production/app:v1"}
+```
+
+### Registry Cleanup
+Remove old or deprecated images from internal registry:
+```yaml
+container_image_mirror_operation: remove
+container_image_mirror_images:
+  - {dest: "deprecated/old-app:v1"}
+  - {dest: "test/temp-image:latest"}
+```
+
+## Notes
+
+- **Continues on error**: The role continues mirroring all images even if some fail, then reports detailed results at the end
+- **Pull secrets**: The role cleans up pull secrets after use for security
+- **TLS verification**: Disabled by default for internal registries with self-signed certificates
+- **Idempotency**: Checks for existing images before mirroring (though still attempts to mirror for freshness)
+- **Namespace handling**: The `container_image_mirror_registry_namespace` is prepended to all destination images
+
+## Troubleshooting
+
+### Skopeo authentication errors
+Ensure `container_image_mirror_pull_secret_string` contains valid credentials:
+```bash
+cat ~/.docker/config.json | base64 -w0
+```
+
+### TLS verification errors
+If using self-signed certificates, ensure `container_image_mirror_dest_tls_verify: false`
+
+### Permission errors during removal
+Ensure the ansible user has sudo access to the registry storage path
+
+### Image not found errors
+Verify source image exists and is accessible:
+```bash
+skopeo inspect docker://quay.io/org/image:tag
+```
+
+## License
+Apache-2.0
+
+## Author Information
+Telco Verification Team - Red Hat

--- a/playbooks/roles/container_image_mirror/defaults/main.yaml
+++ b/playbooks/roles/container_image_mirror/defaults/main.yaml
@@ -1,0 +1,26 @@
+---
+# Default variables for container_image_mirror role
+
+# Operation mode: 'mirror' or 'remove'
+container_image_mirror_operation: mirror
+
+# Target registry configuration
+container_image_mirror_registry_host: "{{ ansible_fqdn }}"
+container_image_mirror_registry_port: 5000
+container_image_mirror_registry_namespace: ""
+
+# TLS verification for destination registry
+container_image_mirror_dest_tls_verify: false
+
+# Pull secret configuration
+container_image_mirror_use_pull_secret: false
+container_image_mirror_pull_secret_path: /tmp/.pull-secret-mirror.json
+container_image_mirror_pull_secret_string: ""
+
+# Registry storage path (for removal operations)
+container_image_mirror_registry_data_path: /home/telcov10n/registry/data/docker/registry/v2/repositories
+
+# List of images to mirror or remove
+# Format: [{"source": "quay.io/org/image:tag", "dest": "namespace/image:tag"}]
+# For removal, only "dest" is required
+container_image_mirror_images: []

--- a/playbooks/roles/container_image_mirror/meta/main.yaml
+++ b/playbooks/roles/container_image_mirror/meta/main.yaml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: container_image_mirror
+  author: Telco Verification Team
+  description: Mirror or remove container images from/to internal registries using skopeo
+  license: Apache-2.0
+  min_ansible_version: "2.9"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+  galaxy_tags:
+    - containers
+    - skopeo
+    - registry
+    - mirror
+
+dependencies: []

--- a/playbooks/roles/container_image_mirror/tasks/main.yaml
+++ b/playbooks/roles/container_image_mirror/tasks/main.yaml
@@ -1,0 +1,25 @@
+---
+- name: Validate required variables
+  ansible.builtin.assert:
+    that:
+      - container_image_mirror_images is defined
+      - container_image_mirror_images | length > 0
+      - container_image_mirror_operation in ['mirror', 'remove']
+    fail_msg: >-
+      container_image_mirror_images must be defined as a non-empty list, and
+      container_image_mirror_operation must be 'mirror' or 'remove'
+
+- name: Display operation configuration
+  ansible.builtin.debug:
+    msg:
+      - "Operation: {{ container_image_mirror_operation | upper }}"
+      - "Target Registry: {{ container_image_mirror_registry_host }}:{{ container_image_mirror_registry_port }}"
+      - "Images: {{ container_image_mirror_images | length }}"
+
+- name: Execute mirror operation
+  ansible.builtin.include_tasks: mirror.yaml
+  when: container_image_mirror_operation == 'mirror'
+
+- name: Execute remove operation
+  ansible.builtin.include_tasks: remove.yaml
+  when: container_image_mirror_operation == 'remove'

--- a/playbooks/roles/container_image_mirror/tasks/mirror.yaml
+++ b/playbooks/roles/container_image_mirror/tasks/mirror.yaml
@@ -1,0 +1,87 @@
+---
+- name: Validate pull secret configuration
+  ansible.builtin.assert:
+    that:
+      - container_image_mirror_pull_secret_string | length > 0
+    fail_msg: "Pull secret authentication is enabled but pull_secret_string is empty. Please provide a valid base64-encoded pull secret."
+  when: container_image_mirror_use_pull_secret | bool
+
+- name: Setup pull secret for mirroring
+  when: container_image_mirror_use_pull_secret | bool
+  block:
+    - name: Ensure pull secret directory exists
+      ansible.builtin.file:
+        path: "{{ container_image_mirror_pull_secret_path | dirname }}"
+        state: directory
+        mode: "0700"
+      when: (container_image_mirror_pull_secret_path | dirname) not in ['/tmp', '/']
+
+    - name: Populate pull secret
+      ansible.builtin.copy:
+        content: "{{ container_image_mirror_pull_secret_string | b64decode | from_json | to_nice_json }}"
+        dest: "{{ container_image_mirror_pull_secret_path }}"
+        mode: "0600"
+      no_log: true
+
+- name: Check if images already exist in registry
+  ansible.builtin.uri:
+    url: "https://{{ container_image_mirror_registry_host }}:{{ container_image_mirror_registry_port }}/v2/{{ container_image_mirror_registry_namespace }}{{ image_item.dest | regex_replace(':.*', '') }}/tags/list"
+    method: GET
+    validate_certs: false
+    status_code: [200, 404, 401]  # 401 = registry requires auth for tag listing
+  register: _image_check
+  loop: "{{ container_image_mirror_images }}"
+  loop_control:
+    loop_var: image_item
+    label: "{{ image_item.dest }}"
+  failed_when: false
+
+- name: Mirror images using skopeo
+  ansible.builtin.command:
+    cmd: >-
+      skopeo copy --all
+      {{ '--authfile ' + container_image_mirror_pull_secret_path if container_image_mirror_use_pull_secret | bool else '' }}
+      {{ '--dest-tls-verify=false' if not container_image_mirror_dest_tls_verify else '' }}
+      docker://{{ image_item.source }}
+      docker://{{ container_image_mirror_registry_host }}:{{ container_image_mirror_registry_port }}/{{ container_image_mirror_registry_namespace }}{{ image_item.dest }}
+  loop: "{{ container_image_mirror_images }}"
+  loop_control:
+    loop_var: image_item
+    label: "{{ image_item.source }} -> {{ container_image_mirror_registry_namespace }}{{ image_item.dest }}"
+  changed_when: true
+  register: _mirror_result
+  failed_when: false
+  ignore_errors: true
+
+- name: Build mirror summary
+  ansible.builtin.set_fact:
+    _mirror_success: "{{ _mirror_result.results | selectattr('rc', 'eq', 0) | list }}"
+    _mirror_failed: "{{ _mirror_result.results | selectattr('rc', 'ne', 0) | list }}"
+
+- name: Display detailed mirror results
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "MIRROR SUMMARY"
+      - "=========================================="
+      - "Total images: {{ container_image_mirror_images | length }}"
+      - "Successfully mirrored: {{ _mirror_success | length }}"
+      - "Failed: {{ _mirror_failed | length }}"
+      - ""
+      - "SUCCESSFUL:"
+      - "{{ _mirror_success | map(attribute='image_item') | map(attribute='dest') | list | join('\n  ✓ ') | indent(2, first=True) }}"
+      - ""
+      - "FAILED:"
+      - "{{ _mirror_failed | map(attribute='image_item') | map(attribute='dest') | list | join('\n  ✗ ') | indent(2, first=True) if _mirror_failed | length > 0 else '  (none)' }}"
+      - "=========================================="
+
+- name: Cleanup pull secret
+  ansible.builtin.file:
+    path: "{{ container_image_mirror_pull_secret_path }}"
+    state: absent
+  when: container_image_mirror_use_pull_secret | bool
+
+- name: Fail if any images failed to mirror
+  ansible.builtin.fail:
+    msg: "{{ _mirror_failed | length }} image(s) failed to mirror. See summary above for details."
+  when: _mirror_failed | length > 0

--- a/playbooks/roles/container_image_mirror/tasks/remove.yaml
+++ b/playbooks/roles/container_image_mirror/tasks/remove.yaml
@@ -1,0 +1,40 @@
+---
+- name: Remove image repositories from registry storage
+  ansible.builtin.file:
+    path: "{{ container_image_mirror_registry_data_path }}/{{ container_image_mirror_registry_namespace }}{{ image_item.dest | regex_replace(':.*', '') }}"
+    state: absent
+  become: true
+  loop: "{{ container_image_mirror_images }}"
+  loop_control:
+    loop_var: image_item
+    label: "{{ container_image_mirror_registry_namespace }}{{ image_item.dest }}"
+  register: _remove_result
+  failed_when: false
+  ignore_errors: true
+
+- name: Build removal summary
+  ansible.builtin.set_fact:
+    _remove_success: "{{ _remove_result.results | selectattr('changed', 'eq', true) | list }}"
+    _remove_failed: "{{ _remove_result.results | selectattr('failed', 'eq', true) | default([]) | list }}"
+
+- name: Display detailed removal results
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "REMOVAL SUMMARY"
+      - "=========================================="
+      - "Total images: {{ container_image_mirror_images | length }}"
+      - "Successfully removed: {{ _remove_success | length }}"
+      - "Failed: {{ _remove_failed | length }}"
+      - ""
+      - "REMOVED:"
+      - "{{ _remove_success | map(attribute='image_item') | map(attribute='dest') | list | join('\n  ✓ ') | indent(2, first=True) }}"
+      - ""
+      - "FAILED:"
+      - "{{ _remove_failed | map(attribute='image_item') | map(attribute='dest') | list | join('\n  ✗ ') | indent(2, first=True) if _remove_failed | length > 0 else '  (none)' }}"
+      - "=========================================="
+
+- name: Fail if any images failed to remove
+  ansible.builtin.fail:
+    msg: "{{ _remove_failed | length }} image(s) failed to remove. See summary above for details."
+  when: _remove_failed | length > 0

--- a/playbooks/telco-kpi/mirror-images.yml
+++ b/playbooks/telco-kpi/mirror-images.yml
@@ -1,0 +1,49 @@
+---
+# Mirror container images to internal registry
+#
+# This playbook uses the container_image_mirror role to mirror images from
+# source registries to a target internal registry.
+#
+# Prerequisites:
+#   - skopeo CLI tool installed on bastion
+#   - Authentication to source registries (via pull_secret or existing auth)
+#   - Target registry reachable
+#
+# Usage:
+#   ansible-playbook playbooks/telco-kpi/mirror-images.yml \
+#     -i inventories/ocp-deployment/build-inventory.py \
+#     --extra-vars "images='[{\"source\":\"quay.io/org/image:tag\",\"dest\":\"namespace/image:tag\"}]'"
+#
+#   # With pull secret
+#   ansible-playbook playbooks/telco-kpi/mirror-images.yml \
+#     -i inventories/ocp-deployment/build-inventory.py \
+#     --extra-vars "images='[...]' pull_secret_string=$(cat ~/.docker/config.json | base64 -w0)"
+#
+# Required variables:
+#   images: List of image mappings with 'source' and 'dest' keys
+#     Example: [{"source": "quay.io/org/image:tag", "dest": "namespace/image:tag"}]
+#
+# Optional variables:
+#   registry_host: Target registry hostname (default: bastion FQDN)
+#   registry_port: Target registry port (default: 5000)
+#   registry_namespace: Namespace prefix for all dest images (default: none)
+#   dest_tls_verify: Verify TLS for dest registry (default: false)
+#   use_pull_secret: Enable pull secret authentication (default: false)
+#   pull_secret_string: Base64-encoded pull secret (only used if use_pull_secret=true)
+#   pull_secret_path: Path to write pull secret file (only used if use_pull_secret=true)
+#
+- name: Mirror container images to internal registry
+  hosts: bastion
+  gather_facts: true
+  roles:
+    - role: container_image_mirror
+      vars:
+        container_image_mirror_operation: mirror
+        container_image_mirror_images: "{{ images }}"
+        container_image_mirror_registry_host: "{{ registry_host | default(ansible_fqdn) }}"
+        container_image_mirror_registry_port: "{{ registry_port | default(5000) }}"
+        container_image_mirror_registry_namespace: "{{ registry_namespace | default('') }}"
+        container_image_mirror_dest_tls_verify: "{{ dest_tls_verify | default(false) }}"
+        container_image_mirror_use_pull_secret: "{{ use_pull_secret | default(false) }}"
+        container_image_mirror_pull_secret_string: "{{ pull_secret_string | default('') }}"
+        container_image_mirror_pull_secret_path: "{{ pull_secret_path | default('/tmp/.pull-secret-mirror.json') }}"

--- a/playbooks/telco-kpi/remove-images.yml
+++ b/playbooks/telco-kpi/remove-images.yml
@@ -1,0 +1,38 @@
+---
+# Remove container images from internal registry
+#
+# This playbook uses the container_image_mirror role to remove images from
+# an internal registry's storage.
+#
+# Prerequisites:
+#   - sudo access to registry storage path on bastion
+#   - Target registry reachable
+#
+# Usage:
+#   ansible-playbook playbooks/telco-kpi/remove-images.yml \
+#     -i inventories/ocp-deployment/build-inventory.py \
+#     --extra-vars "images='[{\"dest\":\"namespace/image:tag\"}]'"
+#
+#   # Remove multiple images
+#   ansible-playbook playbooks/telco-kpi/remove-images.yml \
+#     -i inventories/ocp-deployment/build-inventory.py \
+#     --extra-vars 'images=[{"dest":"ran-test/old-image:v1"},{"dest":"ran-test/deprecated:latest"}]'
+#
+# Required variables:
+#   images: List of image mappings with 'dest' key
+#     Example: [{"dest": "namespace/image:tag"}]
+#
+# Optional variables:
+#   registry_namespace: Namespace prefix for all dest images (default: none)
+#   registry_data_path: Registry storage path (default: /home/telcov10n/registry/data/docker/registry/v2/repositories)
+#
+- name: Remove container images from internal registry
+  hosts: bastion
+  gather_facts: true
+  roles:
+    - role: container_image_mirror
+      vars:
+        container_image_mirror_operation: remove
+        container_image_mirror_images: "{{ images }}"
+        container_image_mirror_registry_namespace: "{{ registry_namespace | default('') }}"
+        container_image_mirror_registry_data_path: "{{ registry_data_path | default('/home/telcov10n/registry/data/docker/registry/v2/repositories') }}"


### PR DESCRIPTION
Implement role-based container image mirroring system for internal registry management, supporting both mirror and removal operations with authentication.

## Problem

Telco-KPIs testing requires mirroring container images to internal registries for disconnected environments and test image management. Previous approach used inline playbook tasks without reusability.

## Solution

Created dedicated `container_image_mirror` Ansible role with playbooks for both mirroring and removal operations:

**Role: playbooks/roles/container_image_mirror/**
- Supports 'mirror' and 'remove' operations via parameter
- Uses skopeo for image operations
- Handles authentication with pull secrets
- Continues operation even if some images fail
- Comprehensive success/failure reporting with summary

**Playbooks:**
- `playbooks/mirror-images.yml` - Mirror images to internal registry
- `playbooks/remove-images.yml` - Remove images from registry storage

## Features

**Authentication:**
- Pull secret support for private registries (via pull_secret_string or pull_secret_path)
- System default auth when no pull secret provided
- Configurable auth file location (/tmp for bastion compatibility)
- use_pull_secret flag to control authentication method

**Registry Configuration:**
- Configurable registry host/port/namespace
- TLS verification control
- Source and destination registry support

**Operations:**
- Idempotent with existence checks
- Detailed mirror/removal summary
- Error handling continues operation on failures

## Usage

**Mirror images:**
```bash
ansible-playbook playbooks/mirror-images.yml \
  -e images='[{"source": "quay.io/image:tag", "dest": "registry.local/namespace/image:tag"}]' \
  -e registry_host=registry.local \
  -e pull_secret_string='{"auths": {...}}'
```

**Remove images:**
```bash
ansible-playbook playbooks/remove-images.yml \
  -e images='[{"dest": "registry.local/namespace/image:tag"}]' \
  -e registry_host=registry.local
```

## Implementation Details

**Role Structure:**
- `defaults/main.yaml` - Default variables
- `tasks/main.yaml` - Entry point with operation dispatch
- `tasks/mirror.yaml` - Mirror images using skopeo
- `tasks/remove.yaml` - Remove images from registry storage
- `meta/main.yaml` - Role metadata
- `README.md` - Comprehensive documentation

**Key Variables:**
- `container_image_mirror_operation`: "mirror" or "remove"
- `container_image_mirror_images`: List of image objects
- `container_image_mirror_registry_host`: Target registry hostname
- `container_image_mirror_pull_secret_string`: JSON pull secret
- `container_image_mirror_use_pull_secret`: Enable/disable authentication

## Benefits

- Reusable role for both mirror and removal operations
- Cleaner separation of concerns
- Easier to test and maintain
- Follows eco-ci-cd role patterns (like ocp_operator_mirror)
- Well-documented with examples
- Jenkins job compatible (uses same variable names)

## Jenkins Integration

Used by `telco-kpis-mirror-ran-test-images` Jenkins job for mirroring RAN test images to internal registries.

Related: Telco-KPIs test infrastructure