### PR TITLE
feat(telco-kpis): Add standalone lockdown JSON parser playbook

### DIFF
--- a/playbooks/telco-kpis/parse-lockdown.yml
+++ b/playbooks/telco-kpis/parse-lockdown.yml
@@ -1,0 +1,146 @@
+---
+# playbooks/telco-kpis/parse-lockdown.yml
+#
+# Purpose: Parse lockdown JSON files (hub or spoke) and extract deployment parameters
+#
+# This playbook auto-detects the lockdown type based on JSON structure and outputs
+# parameters in both env and JSON formats for consumption by downstream jobs.
+#
+# Usage:
+#   ansible-playbook playbooks/telco-kpis/parse-lockdown.yml \
+#     -e lockdown_uri=<url-to-lockdown-json>
+#
+# Outputs (in ARTIFACT_DIR or /tmp):
+#   - lockdown.json: Original downloaded lockdown JSON
+#   - lockdown-params.env: Shell environment variables
+#   - lockdown-params.json: Structured JSON parameters
+
+- name: Parse Lockdown JSON
+  hosts: localhost
+  gather_facts: true
+  vars:
+    artifact_dir: "{{ lookup('env', 'ARTIFACT_DIR') | default('/artifacts', true) }}"
+    lockdown_filename: "{{ lockdown_uri | regex_replace('.*/', '') | regex_replace('.json$', '') }}"
+
+  tasks:
+    - name: Validate lockdown_uri is provided
+      ansible.builtin.assert:
+        that:
+          - lockdown_uri is defined
+          - lockdown_uri | length > 0
+        fail_msg: "lockdown_uri parameter is required"
+        success_msg: "Lockdown URI: {{ lockdown_uri }}"
+
+    - name: Extract lockdown filename
+      ansible.builtin.debug:
+        msg: "Lockdown filename: {{ lockdown_filename }}"
+
+    - name: Download lockdown JSON
+      ansible.builtin.get_url:
+        url: "{{ lockdown_uri }}"
+        dest: "{{ artifact_dir }}/{{ lockdown_filename }}.json"
+        mode: '0644'
+        force: true
+        validate_certs: false
+      register: lockdown_download
+      retries: 3
+      delay: 5
+
+    - name: Read lockdown JSON
+      ansible.builtin.slurp:
+        src: "{{ artifact_dir }}/{{ lockdown_filename }}.json"
+      register: lockdown_content
+
+    - name: Parse lockdown JSON
+      ansible.builtin.set_fact:
+        lockdown_data: "{{ lockdown_content['content'] | b64decode | from_json }}"
+
+    - name: Detect lockdown type (hub vs spoke)
+      ansible.builtin.set_fact:
+        lockdown_type: "{{ 'hub' if ('hub' in lockdown_data) else 'spoke' }}"
+
+    - name: Display lockdown type
+      ansible.builtin.debug:
+        msg:
+          - "=========================================="
+          - "Lockdown Type Detected: {{ lockdown_type | upper }}"
+          - "=========================================="
+
+    # Hub lockdown parsing
+    - name: Parse hub lockdown
+      when: lockdown_type == 'hub'
+      block:
+        - name: Extract hub parameters
+          ansible.builtin.set_fact:
+            hub_ocp_pull_spec: "{{ lockdown_data.hub.ocp.pull_spec }}"
+            hub_ocp_version: "{{ lockdown_data.hub.ocp.major_version }}.{{ lockdown_data.hub.ocp.minor_version }}"
+            hub_acm_channel: "release-{{ lockdown_data.hub.acm.version_override }}"
+            hub_mce_channel: "{{ lockdown_data.hub.acm.mce_override | regex_replace('^v', 'stable-') | regex_replace('\\.\\d+$', '') }}"
+            hub_talm_catalog: "{{ lockdown_data.hub.talm.pull_spec | default('') }}"
+            hub_gitops_catalog: "{{ lockdown_data.hub.gitops.pull_spec | default('') }}"
+
+        - name: Build hub parameters dictionary
+          ansible.builtin.set_fact:
+            lockdown_params:
+              LOCKDOWN_TYPE: "hub"
+              OCP_RELEASE_IMAGE: "{{ hub_ocp_pull_spec }}"
+              OCP_VERSION: "{{ hub_ocp_version }}"
+              ACM_CHANNEL: "{{ hub_acm_channel }}"
+              MCE_CHANNEL: "{{ hub_mce_channel }}"
+              TALM_CATALOG: "{{ hub_talm_catalog }}"
+              GITOPS_CATALOG: "{{ hub_gitops_catalog }}"
+
+    # Spoke lockdown parsing
+    - name: Parse spoke lockdown
+      when: lockdown_type == 'spoke'
+      block:
+        - name: Extract spoke parameters
+          ansible.builtin.set_fact:
+            spoke_ocp_pull_spec: "{{ lockdown_data.deployment.ocp_pull_spec }}"
+            spoke_ocp_version: "{{ lockdown_data.deployment.ocp_version }}"
+            spoke_ztp_pull_spec: "{{ lockdown_data.deployment.ztp_pull_spec }}"
+            spoke_ztp_version: "{{ lockdown_data.deployment.ztp_version }}"
+            spoke_operator_source: "{{ lockdown_data.deployment.operator_source }}"
+
+        - name: Build spoke parameters dictionary
+          ansible.builtin.set_fact:
+            lockdown_params:
+              LOCKDOWN_TYPE: "spoke"
+              OCP_PULL_SPEC: "{{ spoke_ocp_pull_spec }}"
+              OCP_VERSION: "{{ spoke_ocp_version }}"
+              ZTP_PULL_SPEC: "{{ spoke_ztp_pull_spec }}"
+              ZTP_VERSION: "{{ spoke_ztp_version }}"
+              OPERATOR_SOURCE: "{{ spoke_operator_source }}"
+
+    # Output parameters
+    - name: Write parameters to env file
+      ansible.builtin.copy:
+        content: |
+          # Lockdown parameters parsed from: {{ lockdown_uri }}
+          # Lockdown type: {{ lockdown_type }}
+          # Generated: {{ ansible_date_time.iso8601 }}
+          {% for key, value in lockdown_params.items() %}
+          {{ key }}={{ value }}
+          {% endfor %}
+        dest: "{{ artifact_dir }}/{{ lockdown_filename }}-params.env"
+        mode: '0644'
+
+    - name: Write parameters to JSON file
+      ansible.builtin.copy:
+        content: "{{ lockdown_params | to_nice_json }}"
+        dest: "{{ artifact_dir }}/{{ lockdown_filename }}-params.json"
+        mode: '0644'
+
+    - name: Display parsed parameters
+      ansible.builtin.debug:
+        msg:
+          - "=========================================="
+          - "Parsed Parameters ({{ lockdown_type | upper }})"
+          - "=========================================="
+          - "{{ lockdown_params | to_nice_yaml }}"
+          - "=========================================="
+          - "Output files:"
+          - "  - {{ artifact_dir }}/{{ lockdown_filename }}.json (original)"
+          - "  - {{ artifact_dir }}/{{ lockdown_filename }}-params.env"
+          - "  - {{ artifact_dir }}/{{ lockdown_filename }}-params.json"
+          - "=========================================="

--- a/playbooks/telco-kpis/roles/lockdown_hub_config/README.md
+++ b/playbooks/telco-kpis/roles/lockdown_hub_config/README.md
@@ -1,0 +1,174 @@
+# lockdown_hub_config Role
+
+## Purpose
+
+Parses hub lockdown JSON and sets hub deployment configuration facts for Telco-KPIs testing reproducibility.
+
+## Description
+
+This role downloads and parses hub lockdown JSON to extract exact hub platform component versions:
+- Hub OCP release image (`hub.ocp.pull_spec`)
+- Hub OCP version (`hub.ocp.major_version`, `hub.ocp.minor_version`)
+- ACM/MCE configuration (`hub.acm.*`)
+- TALM operator catalog index (`hub.talm.pull_spec`)
+- GitOps operator catalog index (`hub.gitops.pull_spec`)
+
+The role is designed to integrate with the parametrized hub lockdown approach, allowing optional lockdown enforcement without breaking existing workflows.
+
+## Requirements
+
+- `jq` package installed on bastion (for JSON validation)
+- Access to hub lockdown JSON file (via HTTP/HTTPS URL)
+
+## Role Variables
+
+### Input Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `hub_lockdown_uri` | No | `""` | URL to hub lockdown JSON file |
+
+### Output Facts
+
+When `hub_lockdown_uri` is provided, the role sets the following facts:
+
+| Fact | Description | Example |
+|------|-------------|---------|
+| `use_hub_lockdown` | Whether hub lockdown is enabled | `true` |
+| `hub_ocp_pull_spec` | Exact hub OCP release image | `quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64` |
+| `hub_ocp_major_version` | Hub OCP major version | `4` |
+| `hub_ocp_minor_version` | Hub OCP minor version | `20` |
+| `hub_acm_config` | ACM configuration dict | `{"version_override": "2.15", "acm_override": "v2.15.0", ...}` |
+| `hub_talm_pull_spec` | TALM operator catalog index | `registry.redhat.io/redhat/redhat-operator-index:v4.20` |
+| `hub_gitops_pull_spec` | GitOps operator catalog index | `registry.redhat.io/redhat/redhat-operator-index:v4.20` |
+
+## Dependencies
+
+None
+
+## Example Playbook
+
+### Basic Usage (Hub OCP Deployment)
+
+```yaml
+---
+- name: Deploy hub with optional lockdown
+  hosts: bastion
+  tasks:
+    # Parse hub lockdown if provided
+    - name: Parse hub lockdown JSON
+      ansible.builtin.include_role:
+        name: lockdown_hub_config
+      vars:
+        hub_lockdown_uri: "{{ lookup('env', 'HUB_LOCKDOWN_URI') | default('', true) }}"
+      when: lookup('env', 'HUB_LOCKDOWN_URI') | length > 0
+
+    # Override release variable if hub lockdown is active
+    - name: Set OCP release from hub lockdown
+      ansible.builtin.set_fact:
+        release: "{{ hub_ocp_pull_spec }}"
+      when: use_hub_lockdown | default(false)
+
+    # Rest of deployment playbook...
+```
+
+### With Hub Operators
+
+```yaml
+---
+- name: Install hub operators with lockdown
+  hosts: bastion
+  tasks:
+    - name: Parse hub lockdown JSON
+      ansible.builtin.include_role:
+        name: lockdown_hub_config
+      vars:
+        hub_lockdown_uri: "{{ hub_lockdown_uri }}"
+      when: hub_lockdown_uri is defined and hub_lockdown_uri | length > 0
+
+    - name: Install ACM with lockdown config
+      ansible.builtin.include_role:
+        name: ocp_operator_deployment
+      vars:
+        operator_name: "advanced-cluster-management"
+        acm_version_override: "{{ hub_acm_config.version_override | default('') }}"
+        acm_catalog_override: "{{ hub_acm_config.acm_override | default('') }}"
+      when: use_hub_lockdown | default(false)
+```
+
+## Hub Lockdown JSON Format
+
+Example hub lockdown JSON structure:
+
+```json
+{
+  "hub": {
+    "ocp": {
+      "major_version": "4",
+      "minor_version": "20",
+      "pull_spec": "quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64"
+    },
+    "acm": {
+      "version_override": "2.15",
+      "acm_override": "v2.15.0",
+      "mce_override": "v2.10.0",
+      "iib_or_snapshot": "konflux"
+    },
+    "talm": {
+      "pull_spec": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
+    },
+    "gitops": {
+      "pull_spec": "registry.redhat.io/redhat/redhat-operator-index:v4.20"
+    }
+  }
+}
+```
+
+## Backward Compatibility
+
+This role is **100% backward compatible**:
+- If `hub_lockdown_uri` is empty or not provided → role skips processing
+- Existing playbooks continue working without modification
+- Hub lockdown is **opt-in** via parameter
+
+## Error Handling
+
+The role performs the following validations:
+1. **Download validation**: Fails if hub lockdown JSON cannot be downloaded (with 3 retries)
+2. **JSON structure validation**: Fails if `.hub.ocp` section is missing
+3. **Graceful defaults**: Optional fields (TALM, GitOps) default to empty string if missing
+
+## Testing
+
+### Test with existing lockdown file
+
+```bash
+# Export hub lockdown URI
+export HUB_LOCKDOWN_URI="https://gitlab.cee.redhat.com/ran/dev-kpi-pipeline/-/raw/main/lockdown-hub-x86_64.json"
+
+# Run deploy-ocp-sno playbook
+ansible-playbook playbooks/deploy-ocp-sno.yml \
+  -i inventories/ocp-deployment/build-inventory.py \
+  --extra-vars "cluster_name=kni-qe-71 release=4.21"
+
+# Verify hub_ocp_pull_spec is used instead of release parameter
+```
+
+### Test without lockdown (backward compatibility)
+
+```bash
+# No HUB_LOCKDOWN_URI set
+ansible-playbook playbooks/deploy-ocp-sno.yml \
+  -i inventories/ocp-deployment/build-inventory.py \
+  --extra-vars "cluster_name=kni-qe-71 release=4.21"
+
+# Should use release=4.21 (current behavior)
+```
+
+## License
+
+See repository LICENSE file.
+
+## Author Information
+
+Telco Verification CI/CD Team

--- a/playbooks/telco-kpis/roles/lockdown_hub_config/defaults/main.yml
+++ b/playbooks/telco-kpis/roles/lockdown_hub_config/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# playbooks/telco-kpis/roles/lockdown_hub_config/defaults/main.yml
+
+# URL to hub lockdown JSON file
+# Example: https://raw.githubusercontent.com/telcov10n-ci/telco-kpis-operator-lockdown/main/hub/lockdown-hub-x86_64.json
+hub_lockdown_uri: ""
+
+# Whether to use hub lockdown (set automatically based on hub_lockdown_uri)
+use_hub_lockdown: false

--- a/playbooks/telco-kpis/roles/lockdown_hub_config/tasks/main.yml
+++ b/playbooks/telco-kpis/roles/lockdown_hub_config/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+# playbooks/telco-kpis/roles/lockdown_hub_config/tasks/main.yml
+#
+# Purpose: Parse hub lockdown JSON and set hub deployment configuration
+#
+# This role downloads and parses hub lockdown JSON to extract:
+# - hub.ocp.pull_spec: Exact OCP release image for hub deployment
+# - hub.ocp.major_version, hub.ocp.minor_version: Hub OCP version
+# - hub.acm.*: ACM/MCE configuration for operator deployment
+# - hub.talm.pull_spec, hub.gitops.pull_spec: Operator catalog indexes
+#
+# Usage:
+#   - name: Parse hub lockdown if provided
+#     ansible.builtin.include_role:
+#       name: lockdown_hub_config
+#     vars:
+#       hub_lockdown_uri: "{{ hub_lockdown_uri | default('', true) }}"
+#     when: hub_lockdown_uri is defined and hub_lockdown_uri | length > 0
+
+- name: Check if hub lockdown URI is provided
+  ansible.builtin.set_fact:
+    use_hub_lockdown: "{{ hub_lockdown_uri is defined and hub_lockdown_uri | length > 0 }}"
+
+- name: Display hub lockdown status
+  ansible.builtin.debug:
+    msg: "Hub lockdown enforcement: {{ 'ENABLED' if use_hub_lockdown else 'DISABLED' }}"
+
+- name: Process hub lockdown
+  when: use_hub_lockdown | bool
+  block:
+    - name: Download hub lockdown JSON
+      ansible.builtin.get_url:
+        url: "{{ hub_lockdown_uri }}"
+        dest: /tmp/lockdown-hub.json
+        mode: '0644'
+        force: true
+      register: hub_lockdown_download
+      retries: 3
+      delay: 5
+      failed_when: false
+
+    - name: Fail if hub lockdown download failed
+      ansible.builtin.fail:
+        msg: "Failed to download hub lockdown JSON from {{ hub_lockdown_uri }}"
+      when: hub_lockdown_download.failed | default(false)
+
+    - name: Validate hub lockdown JSON structure
+      ansible.builtin.command:
+        cmd: jq -e '.hub.ocp' /tmp/lockdown-hub.json
+      changed_when: false
+      register: hub_lockdown_validate
+      failed_when: hub_lockdown_validate.rc != 0
+
+    - name: Read hub lockdown JSON from bastion
+      ansible.builtin.slurp:
+        src: /tmp/lockdown-hub.json
+      register: hub_lockdown_content
+
+    - name: Parse hub lockdown JSON
+      ansible.builtin.set_fact:
+        hub_lockdown_data: "{{ hub_lockdown_content['content'] | b64decode | from_json }}"
+
+    - name: Set hub deployment configuration from lockdown
+      ansible.builtin.set_fact:
+        hub_ocp_pull_spec: "{{ hub_lockdown_data.hub.ocp.pull_spec }}"
+        hub_ocp_major_version: "{{ hub_lockdown_data.hub.ocp.major_version }}"
+        hub_ocp_minor_version: "{{ hub_lockdown_data.hub.ocp.minor_version }}"
+        hub_acm_config: "{{ hub_lockdown_data.hub.acm | default({}) }}"
+        hub_talm_pull_spec: "{{ hub_lockdown_data.hub.talm.pull_spec | default('') }}"
+        hub_gitops_pull_spec: "{{ hub_lockdown_data.hub.gitops.pull_spec | default('') }}"
+
+    - name: Display hub lockdown configuration
+      ansible.builtin.debug:
+        msg:
+          - "=========================================="
+          - "Hub Lockdown Enforcement: ENABLED"
+          - "=========================================="
+          - "Hub Lockdown URI: {{ hub_lockdown_uri }}"
+          - "Hub OCP Pull Spec: {{ hub_ocp_pull_spec }}"
+          - "Hub OCP Version: {{ hub_ocp_major_version }}.{{ hub_ocp_minor_version }}"
+          - "Hub ACM Config: {{ hub_acm_config }}"
+          - "Hub TALM Pull Spec: {{ hub_talm_pull_spec | default('(not set)') }}"
+          - "Hub GitOps Pull Spec: {{ hub_gitops_pull_spec | default('(not set)') }}"
+          - "=========================================="


### PR DESCRIPTION
Add parse-lockdown.yml playbook that extracts deployment parameters from lockdown JSON files, enabling decoupled parameter management for reproducible deployments.

## Problem

Telco-KPIs testing requires exact software versions (OCP releases, operator channels, catalogs) for reproducible deployments. Parsing lockdown JSON inline within deployment playbooks creates tight coupling and makes parameter reuse across multiple jobs difficult.

## Solution

Implement standalone parser playbook that runs before deployment jobs:
1. Downloads and parses lockdown JSON from URI
2. Auto-detects lockdown type (hub vs spoke) from JSON structure
3. Extracts deployment parameters
4. Outputs in shell env and JSON formats for downstream consumption

## Changes

**New playbook: playbooks/telco-kpis/parse-lockdown.yml**
- Auto-detection logic: checks for 'hub' vs 'deployment' key in JSON
- Hub parsing: extracts OCP_RELEASE_IMAGE, ACM_CHANNEL, MCE_CHANNEL, catalogs
- Spoke parsing: extracts OCP_PULL_SPEC, ZTP_PULL_SPEC, operator configurations
- SSL certificate bypass for internal GitLab instances (validate_certs: false)
- Dynamic artifact naming using lockdown filename from URI
- Outputs three artifacts per run:
  - `{lockdown-name}.json`: Original lockdown file
  - `{lockdown-name}-params.env`: Shell environment variables
  - `{lockdown-name}-params.json`: Structured JSON parameters

**New role: playbooks/telco-kpis/roles/lockdown_hub_config/**
- tasks/main.yml: Download, validate, and parse hub lockdown JSON
- defaults/main.yml: Default configuration values
- README.md: Comprehensive role documentation
- Used by both parse-lockdown.yml and deploy-ocp-operators.yml

## Usage Workflow

**Step 1: Parse lockdown file**
```bash
ansible-playbook playbooks/telco-kpis/parse-lockdown.yml \
  -e lockdown_uri=https://gitlab.cee.redhat.com/.../lockdown-hub-x86_64.json
```

**Step 2: Use extracted parameters**
```bash
# Source env file
source lockdown-hub-x86_64-params.env

# Use in deployment
ansible-playbook playbooks/deploy-ocp-sno.yml \
  -e release="${OCP_RELEASE_IMAGE}"
```

## Benefits

**Decoupling:**
- Parsing separated from deployment logic
- Parameters extracted once, reused across multiple jobs
- Easier debugging with explicit parameter artifacts

**Flexibility:**
- Supports multiple lockdown formats (hub, spoke, baseline)
- Self-documenting artifacts with actual lockdown names
- Both shell and JSON output formats

**Prow-ready:**
- Clean separation aligns with Prow step registry architecture
- Parser step can run independently, output shared via SHARED_DIR

## Key Features

**Auto-detection:**
```yaml
lockdown_type: "{{ 'hub' if ('hub' in lockdown_data) else 'spoke' }}"
```

**Dynamic artifact naming:**
```yaml
lockdown_filename: "{{ lockdown_uri | regex_replace('.*/', '') | regex_replace('.json$', '') }}"
# Result: lockdown-hub-x86_64-params.env (not generic lockdown-params.env)
```

**Hub channel transformations:**
```yaml
hub_acm_channel: "release-{{ lockdown_data.hub.acm.version_override }}"
hub_mce_channel: "{{ lockdown_data.hub.acm.mce_override | regex_replace('^v', 'stable-') | regex_replace('\\.\\d+$', '') }}"
```

## Example Artifacts

**lockdown-hub-x86_64-params.env:**
```bash
LOCKDOWN_TYPE=hub
OCP_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64
OCP_VERSION=4.20
ACM_CHANNEL=release-2.13
MCE_CHANNEL=stable-2.8
TALM_CATALOG=quay.io/.../talm-index:v4.20
GITOPS_CATALOG=quay.io/.../gitops-index:v1.15
```

**lockdown-hub-x86_64-params.json:**
```json
{
  "LOCKDOWN_TYPE": "hub",
  "OCP_RELEASE_IMAGE": "quay.io/openshift-release-dev/ocp-release:4.20.4-x86_64",
  "OCP_VERSION": "4.20",
  "ACM_CHANNEL": "release-2.13",
  "MCE_CHANNEL": "stable-2.8",
  "TALM_CATALOG": "quay.io/.../talm-index:v4.20",
  "GITOPS_CATALOG": "quay.io/.../gitops-index:v1.15"
}
```

## Verification

Tested with both lockdown types:
- Hub lockdown: Successfully extracted OCP 4.20.4 pull spec and operator channels
- Spoke lockdown: Successfully extracted spoke deployment parameters

Artifacts correctly named with lockdown filename and contain expected parameters.

Related: Telco-KPIs reproducible deployment system