### PR TITLE
NROP: rename sample devices according to serial suite docs

### DIFF
--- a/playbooks/compute/roles/nrop_testing/README.md
+++ b/playbooks/compute/roles/nrop_testing/README.md
@@ -21,7 +21,7 @@ You can adjust the execution by providing the following variables:
 | `disconnected_install` | No       | Set `true` for disconnected installs (default: `true`)              |
 | `teardown_timeout`     | No       | Timeout override for teardown stage                                 |
 | `cooldown_timeout`     | No       | Timeout override for cooldown stage                                 |
-| `device_t1/2/3`        | No       | Custom device type override variables                               |
+| `sample_device_type_1/2/3` | No   | Custom device type override variables                               |
 | `ginkgo_focus`         | No       | Regex/filter to focus a subset of E2E tests                        |
 | `ginkgo_skip`          | No       | Regex/filter to skip a subset of E2E tests                         |
 | `run_reboot_tests_only`| No       | Run only tests that require node reboots (`true/false`)             |

--- a/playbooks/compute/roles/nrop_testing/defaults/main.yml
+++ b/playbooks/compute/roles/nrop_testing/defaults/main.yml
@@ -30,9 +30,9 @@ ppc_image: "registry.redhat.io/openshift4/ose-cluster-node-tuning-rhel9-operator
 ppc_image_rhel8: "registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v4.12"
 
 # devices
-device_t1: tty1
-device_t2: tty2
-device_t3: tty3
+sample_device_type_1: example.com/deviceA
+sample_device_type_2: example.com/deviceB
+sample_device_type_3: example.com/deviceC
 
 # Test to skip
 ginkgo_skip: 84312

--- a/playbooks/compute/roles/nrop_testing/templates/nrop_test_script.j2
+++ b/playbooks/compute/roles/nrop_testing/templates/nrop_test_script.j2
@@ -15,14 +15,14 @@ podman run --rm --name nrop-container-tests \
 {% if cooldown_timeout|default("") != "" %}
   -e E2E_NROP_TEST_COOLDOWN={{ cooldown_timeout }} \
 {% endif %}
-{% if device_t1|default("") != "" %}
-  -e E2E_NROP_DEVICE_TYPE_1={{ device_t1 }} \
+{% if sample_device_type_1|default("") != "" %}
+  -e E2E_NROP_DEVICE_TYPE_1={{ sample_device_type_1 }} \
 {% endif %}
-{% if device_t2|default("") != "" %}
-  -e E2E_NROP_DEVICE_TYPE_2={{ device_t2 }} \
+{% if sample_device_type_2|default("") != "" %}
+  -e E2E_NROP_DEVICE_TYPE_2={{ sample_device_type_2 }} \
 {% endif %}
-{% if device_t3|default("") != "" %}
-  -e E2E_NROP_DEVICE_TYPE_3={{ device_t3 }} \
+{% if sample_device_type_3|default("") != "" %}
+  -e E2E_NROP_DEVICE_TYPE_3={{ sample_device_type_3 }} \
 {% endif %}
   -e E2E_NROP_INFRA_SETUP_SKIP=true \
   -e E2E_NROP_MUSTGATHER_IMAGE={{ numa_mustgather_image }} \

--- a/playbooks/compute/roles/nrop_testing/templates/sample-device-A.yaml.j2
+++ b/playbooks/compute/roles/nrop_testing/templates/sample-device-A.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: sample-dev-ns
 data:
   example_com_deviceA.yaml: |
-      devicename: tty1
+      devicename: example.com/deviceA
       devices:
         '*':
           - id: DevA1

--- a/playbooks/compute/roles/nrop_testing/templates/sample-device-B.yaml.j2
+++ b/playbooks/compute/roles/nrop_testing/templates/sample-device-B.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: sample-dev-ns
 data:
   example_com_deviceB.yaml: |
-      devicename: tty2
+      devicename: example.com/deviceB
       devices:
         '*':
           - id: DevB1

--- a/playbooks/compute/roles/nrop_testing/templates/sample-device-C.yaml.j2
+++ b/playbooks/compute/roles/nrop_testing/templates/sample-device-C.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   namespace: sample-dev-ns
 data:
   example_com_deviceC.yaml: |
-      devicename: tty3
+      devicename: example.com/deviceC
       devices:
         '*':
           - id: DevC1


### PR DESCRIPTION
Changing the name of sample devices to the naming convention of the serial suite according to the docs [here](https://github.com/openshift-kni/numaresources-operator/tree/main/test/e2e/serial) 