### PR TITLE
network: temp WA for sriov issue

### DIFF
--- a/playbooks/roles/ocp_operator_deployment/templates/sriov-network-operator-config.j2
+++ b/playbooks/roles/ocp_operator_deployment/templates/sriov-network-operator-config.j2
@@ -8,3 +8,5 @@ spec:
   enableOperatorWebhook: true
   logLevel: 2
   disableDrain: false
+  featureGates:
+    mellanoxFirmwareReset: true


### PR DESCRIPTION
We have a [bug](https://redhat.atlassian.net/browse/OCPBUGS-86028) that blocks our ci runs for 4.22
 This is a temporary work around to unblock our ci runs.