### PR TITLE
Disable insights: remove the use of 'recursive' during replacement

### DIFF
--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -543,7 +543,7 @@
                'auths': pull_secret.auths | dict2items
                  | rejectattr('key', 'equalto', 'cloud.openshift.com')
                  | items2dict
-             }, recursive=True) }}
+             }) }}
 
     - name: Generate deployment manifests for OpenShift installation
       when: (disconnected | bool) is false


### PR DESCRIPTION
Fixes a bug when auth dicts are filtered in order to disable the Insights operator. The original dict, which contained "cloud.openshift.com" was preserved.