### PR TITLE
NTO: fix timeout waiting for cluster post upgrade

### DIFF
--- a/playbooks/compute/roles/cluster_upgrade/tasks/upgrade-cluster.yml
+++ b/playbooks/compute/roles/cluster_upgrade/tasks/upgrade-cluster.yml
@@ -86,8 +86,8 @@
   until:
     - not all_nodes.failed
     - all_nodes.resources | map(attribute='spec.unschedulable', default=false) | select('equalto', true) | list | length == 0
-  retries: 150
-  delay: 10
+  retries: "{{ upgrade_timeout_retries }}"
+  delay: "{{ upgrade_delay }}"
   failed_when: all_nodes.resources | selectattr('spec.unschedulable', 'equalto', true) | list | length > 0
 
 # ---------------------------------------------------------


### PR DESCRIPTION
- fix issue where in Prow the upgrade is timeout, while the cluster does upgrade 