### PR TITLE
Add support for art_fbc for oadp operator

### DIFF
--- a/playbooks/roles/ocp_operator_mirror/tasks/mirror_from_fbc.yaml
+++ b/playbooks/roles/ocp_operator_mirror/tasks/mirror_from_fbc.yaml
@@ -264,6 +264,7 @@
     _image_list: "{{ _image_list | map('regex_replace', '^registry\\.redhat\\.io/', 'registry.stage.redhat.io/') | list }}"
   when:
     - ((operator.ocp_operator_mirror_fbc_image_base | default('')) | length) > 0
+    - not (operator.art_fbc | default(false)) | bool
     - not (('acm' in ((operator.catalog | default('')) | lower)) or ('mce' in ((operator.catalog | default('')) | lower)))
 
 - name: Collect unique source repositories (strip digests)
@@ -320,10 +321,13 @@
       {{
         (_image_pairs | default([])) + [
           {
-            'src': (image
-                    if (((operator.ocp_operator_mirror_fbc_image_base | default('')) | length) > 0)
-                    else ((image | regex_search('@sha256:[0-9a-f]{64}'))
-                          | ternary(ocp_operator_mirror_art_images_share ~ (image | regex_search('@sha256:[0-9a-f]{64}')), image)))
+            'src': (
+                    (ocp_operator_mirror_art_images_share ~ (image | regex_search('@sha256:[0-9a-f]{64}')))
+                    if ((operator.art_fbc | default(false)) | bool)
+                    else (image
+                          if (((operator.ocp_operator_mirror_fbc_image_base | default('')) | length) > 0)
+                          else ((image | regex_search('@sha256:[0-9a-f]{64}'))
+                                | ternary(ocp_operator_mirror_art_images_share ~ (image | regex_search('@sha256:[0-9a-f]{64}')), image))))
             ,
             'dst': (image | regex_replace('^([^/]+)', ocp_operator_mirror_registry_url+'/'+ocp_operator_mirror_folder))
           }


### PR DESCRIPTION
Problem: OADP's ART FBC uses a non-standard tag format (oadp-1.5__v4.20__oadp-rhel9-operator) that requires ocp_operator_mirror_fbc_image_base to be set. But when that field is set, the role pulls component images from registry.stage.redhat.io which doesn't have them. The images actually live in art-images-share on quay.io.

Fix: Added art_fbc flag — when set, the role uses art-images-share for component images even when ocp_operator_mirror_fbc_image_base is specified.