### PR TITLE
Fix MCE default config template to create MultiClusterEngine instead of MultiClusterHub

### DIFF
--- a/playbooks/roles/ocp_operator_deployment/templates/multicluster-engine-config.j2
+++ b/playbooks/roles/ocp_operator_deployment/templates/multicluster-engine-config.j2
@@ -1,6 +1,25 @@
+{#
+  MCE operator resource changed between versions:
+  - MCE < 2.10 (stable-2.8, stable-2.9): MultiClusterHub
+  - MCE >= 2.10 (stable-2.10+): MultiClusterEngine
+  Default to MultiClusterEngine for newer/unknown versions
+#}
+{% set channel = operator_item.channel | default('stable-2.10') %}
+{% set legacy_channels = ['stable-2.8', 'stable-2.9'] %}
+{% if channel in legacy_channels %}
+{# Legacy MCE versions (< 2.10) use MultiClusterHub #}
 apiVersion: operator.open-cluster-management.io/v1
 kind: MultiClusterHub
 metadata:
   name: multiclusterhub
   namespace: "{{ operator_item.nsname }}"
 spec: {}
+{% else %}
+{# Modern MCE versions (>= 2.10) use MultiClusterEngine #}
+apiVersion: multicluster.openshift.io/v1
+kind: MultiClusterEngine
+metadata:
+  name: multiclusterengine
+  namespace: "{{ operator_item.nsname }}"
+spec: {}
+{% endif %}


### PR DESCRIPTION
The template was incorrectly creating a MultiClusterHub (ACM resource) instead of MultiClusterEngine (MCE resource) when deploy_default_config: true.

Root cause: Wrong API group and kind for MCE operator
- apiVersion changed from operator.open-cluster-management.io/v1 to multicluster.openshift.io/v1
- kind changed from MultiClusterHub to MultiClusterEngine
- name changed from multiclusterhub to multiclusterengine

Evidence from kni-qe-71 cluster showing both resources exist:
- MultiClusterHub in multicluster-engine namespace (from buggy template)
- MultiClusterEngine cluster-wide (correct resource)