### PR TITLE
fix: correct BIND zones directory path in create-dns-record playbook

### DIFF
--- a/playbooks/infra/create-dns-record.yml
+++ b/playbooks/infra/create-dns-record.yml
@@ -269,7 +269,7 @@
     - name: Copy zone file to bind zones directory
       ansible.builtin.copy:
         src: "{{ zone_file }}"
-        dest: "{{ ansible_user_dir }}/bind/zones/{{ zone_file | basename }}"
+        dest: "{{ ansible_user_dir }}/.config/bind/zones/{{ zone_file | basename }}"
         mode: "0644"
         remote_src: true
 


### PR DESCRIPTION
The zone file was being copied to ~/bind/zones/ but the BIND container mounts ~/.config/bind/zones/ as /etc/bind/zones/. This caused the updated zone file to never reach the container, leaving BIND serving stale records.