### PR TITLE
Fix ocp_version_facts for OCP 5.0 and improve release-not-found error handling

### DIFF
--- a/playbooks/deploy-ocp-hybrid-multinode.yml
+++ b/playbooks/deploy-ocp-hybrid-multinode.yml
@@ -509,7 +509,7 @@
         name: ocp_version_facts
       vars:
         ocp_version_facts_release: "{{ release }}"
-        ocp_version_release_age_max_days: "{{ release_age_max_days | default(10000) | int }}"
+        ocp_version_release_age_max_days: "{{ release_age_max_days | default(ocp_version_release_age_max_days) | default(10000) | int }}"
 
     - name: Clean HTTP storage directory
       become: true

--- a/playbooks/roles/ocp_version_facts/tasks/version-provided.yml
+++ b/playbooks/roles/ocp_version_facts/tasks/version-provided.yml
@@ -5,11 +5,20 @@
   loop_control:
     loop_var: release_stream
 
-- name: Validate image age days
-  ansible.builtin.assert:
-    that:
-      - (image_age_days | int) <= (ocp_version_release_age_max_days | int)
-    fail_msg: "Image age days {{ image_age_days }} is greater than maximum allowed age {{ ocp_version_release_age_max_days }}"
+- name: Fail if no matching release was found
+  when: ocp_version_facts_query is not defined
+  block:
+    - name: Fail when matched image exceeds maximum age
+      ansible.builtin.fail:
+        msg: "Image age days {{ image_age_days }} is greater than maximum allowed age {{ ocp_version_release_age_max_days }}"
+      when: image_age_days is defined
+
+    - name: Fail when no release matched requested version
+      ansible.builtin.fail:
+        msg: >-
+          No OpenShift release matching '{{ ocp_version_facts_release }}'
+          was found in configured release streams.
+      when: image_age_days is not defined
 
 - name: Set ocp_version_facts_pull_spec,ocp_version_facts_parsed_release and ocp_version_facts_oc_client_pull_link facts
   ansible.builtin.set_fact:

--- a/playbooks/roles/ocp_version_facts/vars/main.yml
+++ b/playbooks/roles/ocp_version_facts/vars/main.yml
@@ -8,3 +8,4 @@ ocp_release_streams:
   - https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/api/v1/releasestream/4-stable/tags
   - https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/api/v1/releasestream/4-dev-preview/tags
   - https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/api/v1/releasestream/4.22.0-0.nightly/tags
+  - https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/api/v1/releasestream/5.0.0-0.nightly/tags

--- a/playbooks/setup-cluster-env.yml
+++ b/playbooks/setup-cluster-env.yml
@@ -112,7 +112,7 @@
         name: ocp_version_facts
       vars:
         ocp_version_facts_release: "{{ release }}"
-        ocp_version_release_age_max_days: "{{ release_age_max_days | default(10000) | int }}"
+        ocp_version_release_age_max_days: "{{ release_age_max_days | default(ocp_version_release_age_max_days) | default(10000) | int }}"
 
     - name: Set cluster name
       ansible.builtin.set_fact:


### PR DESCRIPTION
Fix `ocp_version_facts` failures when deploying OCP 5.0 by adding the `5.0.0-0.nightly` release stream and replacing the misleading `image_age_days` is undefined error with explicit release lookup failure.

Also accept `ocp_version_release_age_max_days` from Jenkins callers, with fallback to `release_age_max_days`.