### PR TITLE
pin oc-mirror to 4.20.8

### DIFF
--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -312,8 +312,6 @@
 - name: Setup bastion host
   hosts: bastion
   gather_facts: true
-  vars:
-    oc_mirror_version: "4.20.8"
   environment:
     REGISTRY_AUTH_FILE: /etc/containers/auth.json
   tasks:
@@ -470,7 +468,7 @@
       vars:
         _oc_mirror_url: >-
           https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{{
-          oc_mirror_version }}/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz
+          oc_mirror_version | default('latest') }}/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz
       ansible.builtin.get_url:
         url: "{{ _oc_mirror_url }}"
         dest: "/tmp/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz"

--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -312,6 +312,8 @@
 - name: Setup bastion host
   hosts: bastion
   gather_facts: true
+  vars:
+    oc_mirror_version: "4.20.8"
   environment:
     REGISTRY_AUTH_FILE: /etc/containers/auth.json
   tasks:
@@ -465,8 +467,12 @@
         state: present
 
     - name: Download oc-mirror archive
+      vars:
+        _oc_mirror_url: >-
+          https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{{
+          oc_mirror_version }}/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz
       ansible.builtin.get_url:
-        url: "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz"
+        url: "{{ _oc_mirror_url }}"
         dest: "/tmp/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz"
         mode: '0644'
 

--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -468,7 +468,8 @@
       vars:
         _oc_mirror_url: >-
           https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{{
-          oc_mirror_version | default('latest') }}/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz
+          ('latest-' ~ oc_mirror_version_minor) if oc_mirror_version_minor is defined else 'latest'
+          }}/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz
       ansible.builtin.get_url:
         url: "{{ _oc_mirror_url }}"
         dest: "/tmp/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz"


### PR DESCRIPTION
Pin oc-mirror to 4.20.8 to avoid issues in unstable oc mirror releases in the future bastion releases.