### PR TITLE
fix CNF/DPDK image version reported in Slack notification

### DIFF
--- a/playbooks/cnf/deploy-run-cnf-tests-script.yaml
+++ b/playbooks/cnf/deploy-run-cnf-tests-script.yaml
@@ -131,6 +131,12 @@
         cnf_tests_rhel: "{{ '9' if version is version('4.20', '>=') else '8' }}"
         dpdk_tests_rhel: "{{ '9' if version is version('4.16', '>=') else '8' }}"
 
+    - name: Store containers version to file
+      ansible.builtin.copy:
+        content: "{{ containers_version }}"
+        dest: "{{ cnf_test_dir }}/containers_version"
+        mode: "0644"
+
     # TODO: Remove this block when OCP 4.14 reaches end-of-life
     - name: Run CNF tests via podman image. OCP < 4.15
       when: ocp_major_version | int == 4 and ocp_minor_version | int < 15

--- a/scripts/network/send-cnf-network-release-notification.py
+++ b/scripts/network/send-cnf-network-release-notification.py
@@ -114,8 +114,10 @@ def parse_arguments():
     parser.add_argument("--version", required=True, help="Release version")
     
     # Optional arguments with defaults
-    parser.add_argument("--registry-url", default="https://registry.stage.redhat.io/openshift4", 
-                       help="Registry URL for images (default: %(default)s)")    
+    parser.add_argument("--registry-url", default="https://registry.stage.redhat.io/openshift4",
+                       help="Registry URL for images (default: %(default)s)")
+    parser.add_argument("--containers-version", default=None,
+                       help="Version tag for CNF/DPDK container images (default: derived from --version)")
     # Direct values
     parser.add_argument("--jira-link", default="", help="Jira card link")
     parser.add_argument("--polarion-url", default="", help="Polarion URL")
@@ -181,6 +183,7 @@ def construct_prow_urls(major, minor, phase1_build_id=None):
 
 def create_release_info(args, rhel_version):
     """Create the release info dictionary."""
+    containers_version = args.containers_version if args.containers_version else args.version
     return {
         "version": args.version,
         "jira_card_link": args.jira_link,
@@ -189,8 +192,8 @@ def create_release_info(args, rhel_version):
             "cluster_name": args.cluster_name,
             "nic": args.nic,
             "secondary_nic": args.secondary_nic,
-            "cnf_image_version": f"{args.registry_url}/cnf-{rhel_version}:v{args.version}",
-            "dpdk_image_version": f"{args.registry_url}/dpdk-base-{rhel_version}:v{args.version}"
+            "cnf_image_version": f"{args.registry_url}/cnf-{rhel_version}:v{containers_version}",
+            "dpdk_image_version": f"{args.registry_url}/dpdk-base-{rhel_version}:v{containers_version}"
         }
     }
 


### PR DESCRIPTION
The notification script was using the OCP z-stream version for CNF/DPDK image tags, but the ansible playbook applies a minor-version offset (e.g. on OCP 4.21 it uses 4.20 images). This caused a mismatch between the images actually used in tests and what was shown in Slack.

- deploy-run-cnf-tests-script.yaml: write containers_version to "{{ cnf_test_dir }}/containers_version" on the bastion
- send-cnf-network-release-notification.py: add --containers-version argument; use it for CNF/DPDK image tags, falling back to --version when not provided for backward compatibility