### PR TITLE
Prune any stopped containers left over after image extraction

### DIFF
--- a/playbooks/ran/mirror-ose-kube-rbac-proxy-wa.yml
+++ b/playbooks/ran/mirror-ose-kube-rbac-proxy-wa.yml
@@ -93,6 +93,10 @@
       environment:
         REGISTRY_AUTH_FILE: "{{ pull_secret_path }}"
 
+    - name: Prune stopped containers left by oc image extract
+      containers.podman.podman_prune:
+        container: true
+
     - name: Read gitops operator catalog content
       ansible.builtin.slurp:
         src: /tmp/gitops-catalog/catalog.json


### PR DESCRIPTION
This change adds a task that runs podman to prune any residual containers left over from the previous `oc image extract` operation.