### PR TITLE
ocp_operator_mirror: Add retry to FBC index image pull

### DIFF
--- a/playbooks/roles/ocp_operator_mirror/tasks/mirror_from_fbc.yaml
+++ b/playbooks/roles/ocp_operator_mirror/tasks/mirror_from_fbc.yaml
@@ -33,6 +33,9 @@
 
 - name: Pull FBC index image
   register: image_info
+  retries: 3
+  delay: 10
+  until: image_info is success
   containers.podman.podman_image:
     name: "{{ operator.ocp_operator_mirror_fbc_image_base | default(ocp_operator_mirror_fbc_image_base) }}"
     tag: "{{ fbc_tag }}"


### PR DESCRIPTION
Retry in case of transient 504 when pulling FBC index images.