### PR TITLE
ran: fix PTP GM reporting pipeline for ReportPortal and Polarion

### DIFF
--- a/playbooks/ran/deploy-run-cnf-gotests-ptp-gm.yaml
+++ b/playbooks/ran/deploy-run-cnf-gotests-ptp-gm.yaml
@@ -121,7 +121,7 @@
   tags: process
   vars:
     downstream_test_report_path: /tmp/downstream_report
-    ptp_report_dir: /tmp/ptp_reports
+    ptp_report_dir: /tmp/test_reports
   tasks:
     - name: Reset ptp_report_dir
       ansible.builtin.file:
@@ -146,7 +146,7 @@
     - name: Copy Polarion reports to destination
       ansible.builtin.copy:
         src: "{{ item.path }}"
-        dest: "{{ ptp_report_dir }}/polarion/"
+        dest: "{{ ptp_report_dir }}/junit/"
         remote_src: true
         mode: "0644"
       loop: "{{ polarion_files.files }}"
@@ -161,7 +161,7 @@
     - name: Copy JUnit reports to destination
       ansible.builtin.copy:
         src: "{{ item.path }}"
-        dest: "{{ ptp_report_dir }}/junit/"
+        dest: "{{ ptp_report_dir }}/polarion/"
         remote_src: true
         mode: "0644"
       loop: "{{ junit_files.files }}"

--- a/playbooks/ran/deploy-run-eco-gotests-ptp-gm.yaml
+++ b/playbooks/ran/deploy-run-eco-gotests-ptp-gm.yaml
@@ -301,7 +301,7 @@
   tags: process
   vars:
     eco_gotest_base_dir: "{{ eco_gotest_base_dir | default('/tmp/eco_gotests_ptp_gm') }}"
-    bastion_report_dir: "{{ ptp_report_dir | default('/tmp/ptp_reports') }}"
+    bastion_report_dir: "{{ ptp_report_dir | default('/tmp/test_reports') }}"
     ptp_cycle_configs: "{{ ptp_cycle_configs | default([]) }}"
     ptp_features:
       - name: containernshide
@@ -322,22 +322,22 @@
 
     - name: Remove stale eco-gotests feature report files from previous runs
       ansible.builtin.shell: |
-        rm -f "{{ bastion_report_dir }}/junit/{{ item.name }}_suite_test.xml"
-        rm -f "{{ bastion_report_dir }}/polarion/{{ item.name }}_suite_test_polarion.xml"
+        rm -f "{{ bastion_report_dir }}/polarion/{{ item.name }}_suite_test.xml"
+        rm -f "{{ bastion_report_dir }}/junit/{{ item.name }}_suite_test_polarion.xml"
       loop: "{{ ptp_features }}"
       changed_when: false
 
     - name: Remove stale eco-gotests PTP cycle report files from previous runs
       ansible.builtin.shell: |
-        rm -f {{ bastion_report_dir }}/junit/ptp_gm_*_suite_test.xml
-        rm -f {{ bastion_report_dir }}/polarion/ptp_gm_*_suite_test_polarion.xml
+        rm -f {{ bastion_report_dir }}/polarion/ptp_gm_*_suite_test.xml
+        rm -f {{ bastion_report_dir }}/junit/ptp_gm_*_suite_test_polarion.xml
       changed_when: false
       failed_when: false
 
     - name: Rename testsuite and prepare feature JUnit reports for ReportPortal
       ansible.builtin.shell: |
         src="/tmp/eco_gotests_{{ item.name }}_0/report/{{ item.junit }}"
-        dst="{{ bastion_report_dir }}/junit/{{ item.name }}_suite_test.xml"
+        dst="{{ bastion_report_dir }}/polarion/{{ item.name }}_suite_test.xml"
         if [ -f "${src}" ]; then
           sed "s/testsuites name=\"[^\"]*\"/testsuites name=\"{{ item.name }}\"/g;
                s/testsuite name=\"[^\"]*\"/testsuite name=\"{{ item.name }}\"/g" \
@@ -349,10 +349,9 @@
     - name: Prepare feature Polarion reports for Polarion converter
       ansible.builtin.shell: |
         src="/tmp/eco_gotests_{{ item.name }}_0/report/report_testrun.xml"
-        dst="{{ bastion_report_dir }}/polarion/{{ item.name }}_suite_test_polarion.xml"
+        dst="{{ bastion_report_dir }}/junit/{{ item.name }}_suite_test_polarion.xml"
         if [ -f "${src}" ]; then
-          sed "s/testsuite name=\"[^\"]*\"/testsuite name=\"{{ item.name }}\"/g" \
-            "${src}" > "${dst}"
+          sed "s/testsuite name=\"[^\"]*\"/testsuite name=\"{{ item.name }}\"/g" "${src}" > "${dst}"
         fi
       loop: "{{ ptp_features }}"
       changed_when: false
@@ -361,7 +360,7 @@
     - name: Rename testsuite and prepare PTP ZTP cycle JUnit report for ReportPortal
       ansible.builtin.shell: |
         src="{{ eco_gotest_base_dir }}_0/report/ptp_suite_test_junit.xml"
-        dst="{{ bastion_report_dir }}/junit/ptp_gm_0_suite_test.xml"
+        dst="{{ bastion_report_dir }}/polarion/ptp_gm_0_suite_test.xml"
         if [ -f "${src}" ]; then
           sed "s/testsuites name=\"[^\"]*\"/testsuites name=\"gm\"/g;
                s/testsuite name=\"[^\"]*\"/testsuite name=\"gm\"/g" \
@@ -372,10 +371,9 @@
     - name: Prepare PTP ZTP cycle Polarion report for Polarion converter
       ansible.builtin.shell: |
         src="{{ eco_gotest_base_dir }}_0/report/report_testrun.xml"
-        dst="{{ bastion_report_dir }}/polarion/ptp_gm_0_suite_test_polarion.xml"
+        dst="{{ bastion_report_dir }}/junit/ptp_gm_0_suite_test_polarion.xml"
         if [ -f "${src}" ]; then
-          sed "s/testsuite name=\"[^\"]*\"/testsuite name=\"gm\"/g" \
-            "${src}" > "${dst}"
+          sed "s/testsuite name=\"[^\"]*\"/testsuite name=\"gm\"/g" "${src}" > "${dst}"
         fi
       changed_when: false
       failed_when: false
@@ -383,7 +381,7 @@
     - name: Rename testsuite and prepare PTP GM cycle JUnit reports for ReportPortal
       ansible.builtin.shell: |
         src="{{ eco_gotest_base_dir }}_{{ cycle_idx + 1 }}/report/ptp_suite_test_junit.xml"
-        dst="{{ bastion_report_dir }}/junit/ptp_gm_{{ cycle_idx + 1 }}_suite_test.xml"
+        dst="{{ bastion_report_dir }}/polarion/ptp_gm_{{ cycle_idx + 1 }}_suite_test.xml"
         if [ -f "${src}" ]; then
           sed "s/testsuites name=\"[^\"]*\"/testsuites name=\"{{ item.name }}\"/g;
                s/testsuite name=\"[^\"]*\"/testsuite name=\"{{ item.name }}\"/g" \
@@ -397,10 +395,9 @@
     - name: Prepare PTP GM cycle Polarion reports for Polarion converter
       ansible.builtin.shell: |
         src="{{ eco_gotest_base_dir }}_{{ cycle_idx + 1 }}/report/report_testrun.xml"
-        dst="{{ bastion_report_dir }}/polarion/ptp_gm_{{ cycle_idx + 1 }}_suite_test_polarion.xml"
+        dst="{{ bastion_report_dir }}/junit/ptp_gm_{{ cycle_idx + 1 }}_suite_test_polarion.xml"
         if [ -f "${src}" ]; then
-          sed "s/testsuite name=\"[^\"]*\"/testsuite name=\"{{ item.name }}\"/g" \
-            "${src}" > "${dst}"
+          sed "s/testsuite name=\"[^\"]*\"/testsuite name=\"{{ item.name }}\"/g" "${src}" > "${dst}"
         fi
       loop: "{{ ptp_cycle_configs }}"
       loop_control:

--- a/playbooks/ran/templates/run_eco_gotests_ptp_gm.sh.j2
+++ b/playbooks/ran/templates/run_eco_gotests_ptp_gm.sh.j2
@@ -40,6 +40,7 @@ podman run -it --rm --net=host --uidmap 0:1:1000 --uidmap 1000:0:1 --uidmap 1001
 echo "=== Running {{ feat_config.name }} ==="
 rm -rf {{ feat_dir }}/report
 mkdir -p {{ feat_dir }}/report
+chmod 777 {{ feat_dir }}/report
 {{ podman_run(feat_config.name, feat_dir ~ '/report', feat_config.additional_test_env_variables | default('')) }} || true
 
 {% endfor %}
@@ -57,6 +58,7 @@ sleep 15m
 
 rm -rf {{ eco_gotest_base_dir }}_{{ loop.index }}/report
 mkdir -p {{ eco_gotest_base_dir }}_{{ loop.index }}/report
+chmod 777 {{ eco_gotest_base_dir }}_{{ loop.index }}/report
 {{ podman_run('ptp', eco_gotest_base_dir ~ '_' ~ loop.index ~ '/report', additional_test_env_variables | default('')) }} || true
 
 {% endfor %}


### PR DESCRIPTION
1. Directory swap: JUnit XML must go to polarion/ and Polarion XML to junit/ so that upload-report.yaml passes the correct files as POLARION_REPORT_PATH (JUnit, read by converter.py) and JUNIT_REPORT_PATH (Polarion, sent to ReportPortal), matching the pattern used by the PTP SNO lane. Applied to both eco-gotests and cnf-gotests process steps.

2. Report directory permissions: rootless podman with --uidmap 0:1:1000 maps container root (UID 0) to bastion UID 1, which has no write access to report dirs created by telcov10n (UID 1000). ginkgo and eco-gotests fail to write JUnit and Polarion XML files, resulting in 0 tests reported. Add chmod 777 after mkdir -p for each report directory so the container can write regardless of UID mapping.