### PR TITLE
fix: use ptp-must-gather-rhel8 for OCP < 4.16

### DIFF
--- a/playbooks/ran/deploy-run-eco-gotests-ptp.yaml
+++ b/playbooks/ran/deploy-run-eco-gotests-ptp.yaml
@@ -167,6 +167,14 @@
           register: skopeo_v2_result
           changed_when: false
 
+        - name: Set ptp-must-gather source image name
+          when: version.split('.')[1] | int < 21
+          ansible.builtin.set_fact:
+            ptp_must_gather_src: >-
+              registry.redhat.io/openshift4/{{
+              'ptp-must-gather-rhel9' if version.split('.')[1] | int >= 16
+              else 'ptp-must-gather-rhel8' }}:v{{ version }}
+
         - name: Mirror ptp-must-gather image (OCP < 4.21 only)
           when: version.split('.')[1] | int < 21
           ansible.builtin.command: >
@@ -174,7 +182,7 @@
             --dest-tls-verify=false
             --all
             --authfile {{ pull_secret_file | default('/tmp/auth.json') }}
-            docker://registry.redhat.io/openshift4/ptp-must-gather-rhel9:v{{ version }}
+            docker://{{ ptp_must_gather_src }}
             docker://{{ mirror_registry }}/ran-test/ptp-must-gather:v{{ version }}
           register: skopeo_must_gather_result
           changed_when: false
@@ -184,7 +192,7 @@
             ptp_event_consumer_image: "{{ mirror_registry }}/ran-test/cloud-event-consumer"
 
         - name: Set PTP must-gather mirror fact (OCP < 4.21 only)
-          when: version.split('.')[1] | int < 21
+          when: version.split('.')[1] | int < 21 and skopeo_must_gather_result is not failed
           ansible.builtin.set_fact:
             ptp_must_gather_image: "{{ mirror_registry }}/ran-test/ptp-must-gather:v{{ version }}"
 
@@ -236,7 +244,7 @@
   tags: process
   vars:
     eco_gotest_base_dir: "{{ eco_gotest_base_dir | default('/tmp/eco_gotests') }}"
-    bastion_report_dir: "{{ ptp_report_dir | default('/tmp/ptp_reports') }}"
+    bastion_report_dir: "{{ ptp_report_dir | default('/tmp/test_reports') }}"
     ptp_cycles:
       - { index: 0, name: "BC-OC" }
       - { index: 1, name: "OC2port" }


### PR DESCRIPTION
ptp-must-gather-rhel9 has no v4.14 tag — the rhel9 variant was not published for OCP 4.14. Use ptp-must-gather-rhel8 for versions < 4.16 and ptp-must-gather-rhel9 for 4.16-4.20, consistent with the operator image naming convention (ose-ptp-operator vs ose-ptp-rhel9-operator).