### PR TITLE
fix: use netloc to preserve IPv6 brackets and port in BMC host extrac…

### DIFF
--- a/playbooks/ran/deploy-run-eco-gotests-ptp-gm.yaml
+++ b/playbooks/ran/deploy-run-eco-gotests-ptp-gm.yaml
@@ -133,9 +133,9 @@
             kubeconfig: "{{ hub_kubeconfig }}"
           register: spoke_bmc_host
 
-        - name: Extract BMC IP from spoke BMC address
+        - name: Extract BMC host from spoke BMC address
           ansible.builtin.set_fact:
-            spoke_bmc_ip: "{{ (spoke_bmc_host.resources[0].spec.bmc.address | ansible.builtin.urlsplit).hostname }}"
+            spoke_bmc_ip: "{{ spoke_bmc_host.resources[0].spec.bmc.address | ansible.builtin.urlsplit('netloc') }}"
 
         - name: Write spoke kubeconfig to test directory
           ansible.builtin.copy:


### PR DESCRIPTION
…tion

urlsplit('hostname') strips brackets from IPv6 addresses, causing Go's URL parser to fail when constructing the Redfish endpoint URL. Using netloc instead preserves brackets for IPv6 and retains any non-default port in the extracted value.