### PR TITLE
Fix disconnected detection for dual-stack clusters

### DIFF
--- a/playbooks/cnf/tasks/mirror_images_if_disconnected.yaml
+++ b/playbooks/cnf/tasks/mirror_images_if_disconnected.yaml
@@ -11,6 +11,11 @@
       ansible.builtin.set_fact:
         cluster_disconnected: true
 
+- name: Force disconnected mode when local mirror registry is configured
+  when: use_local_mirror_registry | default(false) | bool
+  ansible.builtin.set_fact:
+    cluster_disconnected: true
+
 - name: Mirror test images to disconnected registry and configure cluster mirroring
   when: cluster_disconnected
   block:


### PR DESCRIPTION
The CNF mirror task only detected disconnected mode on single-stack IPv6 clusters. Dual-stack disconnected clusters were missed, so test images were never mirrored. Honor the existing variable `use_local_mirror_registry` to force disconnected mode regardless of network topology.