### PR TITLE
fix issue when deploying a VM the connection name is already changed

### DIFF
--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -352,7 +352,18 @@
         name: "{{ hostname }}"
       become: true
 
+    - name: Display current connection list
+      become: true
+      ansible.builtin.command: nmcli connection show
+      register: nmcli_connection_list
+      changed_when: false
+
+    - name: Show connection list
+      ansible.builtin.debug:
+        var: nmcli_connection_list.stdout_lines
+
     - name: Rename external connection
+      when: "'System external-connection' in nmcli_connection_list.stdout"
       become: true
       ansible.builtin.command: nmcli connection modify "System external-connection" connection.id external
       changed_when: false


### PR DESCRIPTION
example for the error

```console
TASK [Rename external connection] *******************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /Users/eifrach/git/eco-ci-cd/playbooks/infra/deploy-vm-bastion-libvirt.yml:355
Wednesday 22 July 2026  15:53:35 +0300 (0:00:21.180)       0:16:37.258 ********
Wednesday 22 July 2026  15:53:35 +0300 (0:00:21.180)       0:16:37.257 ********
fatal: [bastion]: FAILED! => changed=false
  cmd:
  - nmcli
  - connection
  - modify
  - System external-connection
  - connection.id
  - external
  delta: '0:00:00.031919'
  end: '2026-07-22 08:53:52.856752'
  msg: non-zero return code
  rc: 10
  start: '2026-07-22 08:53:52.824833'
  stderr: 'Error: unknown connection ''System external-connection''.'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
  ```