### PR TITLE
NROP: gate PerformanceProfile apply in testing

### DIFF
--- a/playbooks/compute/configure-nrop-operator.yml
+++ b/playbooks/compute/configure-nrop-operator.yml
@@ -1,7 +1,6 @@
 ---
 # configure-nrop-operator.yml
-# This playbook configures the NROP operator on the cluster.
-# It sets the target pool, the scheduler image uri, and deploys the operator manifest.
+# Configures NROP on the cluster: operator CRs, PerformanceProfile, and sample devices.
 
 # Variables required:
 # kubeconfig: The kubeconfig to use.
@@ -9,6 +8,8 @@
 
 # Variables optional:
 # custom_scheduler: The custom scheduler to use.
+# topology_manager_scope: pod | container (default: pod)
+# schedulable_master: Make masters schedulable before applying CRs.
 
 
 - name: Configure NROP operator

--- a/playbooks/compute/roles/deploy_nrop_tests/README.md
+++ b/playbooks/compute/roles/deploy_nrop_tests/README.md
@@ -24,6 +24,7 @@ You can adjust the execution by providing the following variables:
 | `sample_device_type_1/2/3` | No   | Custom device type override variables                               |
 | `ginkgo_focus`         | No       | Regex/filter to focus a subset of E2E tests                        |
 | `ginkgo_skip`          | No       | Regex/filter to skip a subset of E2E tests                         |
+| `apply_performance_profile` | No  | Apply PerformanceProfile for the phase TM scope before tests (default: `false`) |
 | `run_reboot_tests_only`| No       | Run only tests that require node reboots (`true/false`)             |
 | `ginkgo_label`         | No       | Custom test label filter                                            |
 | `skip_filter`          | No       | Additional skip filter for label selection                          |

--- a/playbooks/compute/roles/deploy_nrop_tests/defaults/main.yml
+++ b/playbooks/compute/roles/deploy_nrop_tests/defaults/main.yml
@@ -4,6 +4,7 @@ nrop_test_dir: "{{ tmp_workdir }}/tests"
 
 dry_run: true
 run_reboot_tests_only: false
+apply_performance_profile: false
 
 test_env: prod
 scope: "pod"

--- a/playbooks/compute/roles/deploy_nrop_tests/tasks/main.yml
+++ b/playbooks/compute/roles/deploy_nrop_tests/tasks/main.yml
@@ -26,13 +26,15 @@
     scope: "reboot"
   when: run_reboot_tests_only | bool
 
-- name: Generate performance profile
+# Optional PP apply (e.g. Pod→Container scope change, or standalone APPLY_PERFORMANCE_PROFILE).
+# Reboot-only uses pod TM scope.
+- name: Apply PerformanceProfile
   ansible.builtin.include_role:
     name: nrop_config
   vars:
     deploy_performance_profile_only: true
-    topology_manager_scope: "{% if scope == 'reboot' %}pod{% else %}{{ scope }}{% endif %}"
-  when: scope != "reboot"
+    topology_manager_scope: "{{ 'pod' if scope == 'reboot' else scope }}"
+  when: apply_performance_profile | default(false) | bool
 
 - name: Gather sha images
   ansible.builtin.include_tasks: get_image_sha.yml

--- a/playbooks/compute/roles/nrop_config/tasks/deploy_scheduler.yml
+++ b/playbooks/compute/roles/nrop_config/tasks/deploy_scheduler.yml
@@ -52,4 +52,6 @@
 
 - name: Wait for MCP restart
   ansible.builtin.include_tasks: wait_for_mcp.yml
-  when: (ocp_version_major ~ '.' ~ ocp_version_minor) is version('4.18', '<')
+  when:
+    - (ocp_version_major ~ '.' ~ ocp_version_minor) is version('4.18', '<')
+    - deploy_performance_profile_only | bool is false


### PR DESCRIPTION
Only apply PP from deploy_nrop_tests when apply_performance_profile is set, so operators own initial PP/devices and testing can re-apply on scope changes.