### PR TITLE
NROP: move scheduler to sha image instead of version

### DIFF
--- a/playbooks/compute/roles/nrop_config/tasks/deploy_scheduler.yml
+++ b/playbooks/compute/roles/nrop_config/tasks/deploy_scheduler.yml
@@ -27,12 +27,33 @@
 
 - name: Print target pool
   ansible.builtin.debug:
-    msg: "Traget pool: {{ nrop_target_pool }}"
+    msg: "Target pool: {{ nrop_target_pool }}"
 
-- name: Set scheduler image uri
-  ansible.builtin.set_fact:
-    scheduler_image_uri: "{{ image_uri[test_env] }}/{{ scheduler_image_name }}-{{ base_image }}:v{{ ocp_version_major }}.{{ ocp_version_minor }}"
+- name: Set scheduler
   when: custom_scheduler is not defined
+  block:
+    - name: Set scheduler image uri
+      ansible.builtin.set_fact:
+        scheduler_image_version: "{{ image_uri[test_env] }}/{{ scheduler_image_name }}-{{ base_image }}:v{{ ocp_version_major }}.{{ ocp_version_minor }}"
+
+    - name: Save pull secret
+      ansible.builtin.copy:
+        content: "{{ pull_secret_string | b64decode }}"
+        dest: /tmp/pull_secret
+        mode: '0660'
+
+    - name: Get scheduler sha256
+      ansible.builtin.command: >-
+        skopeo --override-os linux --override-arch amd64 inspect
+        --authfile /tmp/pull_secret
+        --format {{ (scheduler_image_version.split(':')[0] ~ '@{{.Digest}}') | quote }}
+        docker://{{ scheduler_image_version }}
+      register: scheduler_image_sha
+      changed_when: false
+
+    - name: Set image name
+      ansible.builtin.set_fact:
+        scheduler_image_uri: "{{ scheduler_image_sha.stdout }}"
 
 - name: Overwrite scheduler image uri
   ansible.builtin.set_fact:


### PR DESCRIPTION
fix for OCPBUG.
- allows only  verified sha256 images