### PR TITLE
day2 worker: Loop CSR approval until kubelet cert rotation stabilizes

### DIFF
--- a/playbooks/ran/deploy-ocp-sno-day2-worker.yml
+++ b/playbooks/ran/deploy-ocp-sno-day2-worker.yml
@@ -285,25 +285,26 @@
           retries: 90
           delay: 60
 
-        - name: Get all CertificateSigningRequests from the spoke cluster
-          kubernetes.core.k8s_info:
-            api_version: certificates.k8s.io/v1
-            kind: CertificateSigningRequest
-            kubeconfig: "{{ spoke_kubeconfig }}"
-          register: all_csrs
-
-        - name: Approve pending kubelet-serving CSRs for the worker node
-          ansible.builtin.command:
-            cmd: >-
-              oc --kubeconfig {{ spoke_kubeconfig }}
-              adm certificate approve {{ item.metadata.name }}
-          loop: "{{ all_csrs.resources | default([]) }}"
-          loop_control:
-            label: "{{ item.metadata.name }}"
-          when:
-            - item.spec.signerName == 'kubernetes.io/kubelet-serving'
-            - (item.status.conditions | default([])) | length == 0
-          changed_when: true
+        - name: Approve pending kubelet-serving CSRs until stable
+          ansible.builtin.shell:
+            cmd: |
+              set -o pipefail
+              pending=$(oc --kubeconfig {{ spoke_kubeconfig }} get csr -o json \
+                | jq -r '.items[]
+                    | select(.spec.signerName == "kubernetes.io/kubelet-serving")
+                    | select((.status.conditions // []) | length == 0)
+                    | .metadata.name')
+              if [ -z "$pending" ]; then
+                echo "no_pending"
+                exit 0
+              fi
+              echo "$pending" | xargs oc --kubeconfig {{ spoke_kubeconfig }} adm certificate approve
+              echo "approved"
+          register: csr_result
+          until: csr_result.stdout_lines | last == "no_pending"
+          retries: 10
+          delay: 30
+          changed_when: '"approved" in csr_result.stdout'
 
         - name: Wait for all ClusterServiceVersions to succeed on the spoke cluster
           kubernetes.core.k8s_info:


### PR DESCRIPTION
The one-shot CSR approval could not catch kubelet-serving CSRs that appeared after the task ran, causing TLS failures in tests.