### PR TITLE
Harden download verification and credential handling in CI playbooks

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -3,15 +3,17 @@ on:
   pull_request:
     branches:
       - "*"
+permissions:
+  contents: read
 jobs:
   build:
     name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,12 +3,14 @@ callbacks_enabled = profile_tasks, profile_roles
 stdout_callback = yaml
 task_output_limit = 10
 collections_path = ./collections
+# TODO: Review ways to reenable host key checking
 host_key_checking = False
 force_color = True
 roles_path = ./playbooks/roles:./playbooks/compute/roles:./playbooks/infra/roles
 
 [ssh_connection]
 retries = 3
+# TODO: Review ways to reenable host key checking
 ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o GSSAPIAuthentication=no"
 control_path = %(directory)s/%%h-%%r
 control_path_dir = ~/.ansible/cp

--- a/playbooks/compute/roles/configurecluster/tasks/ppc.yml
+++ b/playbooks/compute/roles/configurecluster/tasks/ppc.yml
@@ -33,11 +33,18 @@
   when:
     - (ocp_version_major ~ '.' ~ ocp_version_minor) is version('4.19', '<')
 
+- name: Create private tempfile for pull secret
+  ansible.builtin.tempfile:
+    state: file
+    suffix: .pull_secret
+  register: ppc_pull_secret_tmp
+
 - name: Save pull secret
   ansible.builtin.copy:
     content: "{{ pull_secret_string | b64decode }}"
-    dest: /tmp/pull_secret
-    mode: '0660'
+    dest: "{{ ppc_pull_secret_tmp.path }}"
+    mode: '0600'
+  no_log: true
 
 - name: Generate Performance Profile using PPC container
   containers.podman.podman_container:
@@ -46,7 +53,7 @@
     rm: true
     entrypoint: performance-profile-creator
     detach: false
-    authfile: /tmp/pull_secret
+    authfile: "{{ ppc_pull_secret_tmp.path }}"
     volumes:
       - "/tmp/must-gather:/must-gather:Z"
     command: >

--- a/playbooks/deploy-ocp-hybrid-multinode.yml
+++ b/playbooks/deploy-ocp-hybrid-multinode.yml
@@ -563,7 +563,7 @@
             src: "{{ pull_secret_file }}"
             remote_src: true
             dest: "$XDG_RUNTIME_DIR/containers/auth.json"
-            mode: "0644"
+            mode: "0600"
 
         - name: Mirror OpenShift release (disconnected)
           vars:

--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -333,7 +333,7 @@
             src: "{{ pull_secret_file }}"
             remote_src: true
             dest: "$XDG_RUNTIME_DIR/containers/auth.json"
-            mode: "0644"
+            mode: "0600"
 
         - name: Mirror OpenShift release (disconnected)
           vars:

--- a/playbooks/infra/deploy-bm-hypervisor.yml
+++ b/playbooks/infra/deploy-bm-hypervisor.yml
@@ -38,6 +38,9 @@
 #   bmc_user: 'user'                                      # Username for BMC authentication
 #   ssh_public_key: 'public_ssh_key'                      # Public SSH key for authentication after bare-metal installation
 #   system_rpm_link: http://example.rpm                   # URL to the RPM package used for system activation
+#   system_rpm_sha256: 'deadbeef...'                       # sha256 of the artifact at system_rpm_link
+#   ca_update_link: https://example/ca.crt                 # URL to the CA certificate to trust
+#   ca_update_sha256: 'deadbeef...'                        # sha256 of the artifact at ca_update_link
 
 # hypervisor:
 #   ansible_host: 10.1.1.1                                # IP address or hostname of the hypervisor
@@ -161,6 +164,7 @@
       ansible.builtin.get_url:
         url: "{{ system_rpm_link }}"
         dest: "{{ system_rpm_path }}"
+        checksum: "sha256:{{ system_rpm_sha256 }}"
         force: false
         mode: "0640"
 
@@ -168,7 +172,7 @@
       ansible.builtin.dnf:
         name: "{{ system_rpm_path }}"
         state: present
-        disable_gpg_check: true
+        disable_gpg_check: false
 
     - name: Activate OS
       ansible.builtin.command:
@@ -364,6 +368,7 @@
           ansible.builtin.get_url:
             url: "{{ ca_update_link }}"
             dest: /etc/pki/ca-trust/source/anchors/certificate.crt
+            checksum: "sha256:{{ ca_update_sha256 }}"
             mode: '0644'
 
         - name: Update certificate

--- a/playbooks/infra/deploy-vm-bastion-libvirt.yml
+++ b/playbooks/infra/deploy-vm-bastion-libvirt.yml
@@ -42,6 +42,10 @@
 #   bmc_user: 'user'                            # Username for BMC authentication
 #   ssh_public_key: 'public_ssh_key'            # Public SSH key for authentication after bare-metal installation
 #   system_rpm_link: http://example.rpm         # URL to the RPM package used for system activation
+#   system_rpm_sha256: 'deadbeef...'            # sha256 of the artifact at system_rpm_link
+#   ca_update_link: https://example/ca.crt      # URL to the CA certificate to trust
+#   ca_update_sha256: 'deadbeef...'             # sha256 of the artifact at ca_update_link
+#   oc_mirror_sha256: 'deadbeef...'             # sha256 of the resolved oc-mirror.rhel*.tar.gz
 
 # hypervisor:
 #   ansible_host: 10.1.1.1                      # IP address or hostname of the hypervisor
@@ -62,6 +66,7 @@
 #   vm_external_interface: eno0         # External network interface for the VM
 #   vm_ram: "16384"                     # Amount of RAM allocated to the VM (in megabytes)
 #   golang_pkg: go1.24.2.linux-amd64.tar.gz     # golang package version
+#   golang_pkg_sha256: 'deadbeef...'            # sha256 of https://go.dev/dl/{{ golang_pkg }}
 #   brew_repo: https://download.repo/brew.repo  # link to brew repo
 
 # Roles/Tasks Overview:
@@ -255,6 +260,7 @@
       ansible.builtin.get_url:
         url: "{{ system_rpm_link }}"
         dest: "{{ system_rpm_path }}"
+        checksum: "sha256:{{ system_rpm_sha256 }}"
         force: false
         mode: "0640"
 
@@ -262,7 +268,7 @@
       ansible.builtin.dnf:
         name: "{{ system_rpm_path }}"
         state: present
-        disable_gpg_check: true
+        disable_gpg_check: false
 
     - name: Activate OS
       ansible.builtin.command:
@@ -372,6 +378,7 @@
           ansible.builtin.get_url:
             url: "{{ ca_update_link }}"
             dest: /etc/pki/ca-trust/source/anchors/certificate.crt
+            checksum: "sha256:{{ ca_update_sha256 }}"
             mode: '0644'
 
         - name: Update certificate
@@ -407,6 +414,7 @@
       ansible.builtin.get_url:
         url: "https://go.dev/dl/{{ golang_pkg }}"
         dest: /tmp/
+        checksum: "sha256:{{ golang_pkg_sha256 }}"
         mode: '0640'
 
     - name: Ensure destination GO directory exists
@@ -435,7 +443,7 @@
       become: true
       ansible.builtin.copy:
         content: "export REGISTRY_AUTH_FILE=/etc/containers/auth.json"
-        dest: /etc/profile.d/podman-auth-var.sh
+        dest: /etc/p1rofile.d/podman-auth-var.sh
         mode: "0755"
 
     # TODO: Uncomment once rehdatci bump completed
@@ -474,6 +482,7 @@
       ansible.builtin.get_url:
         url: "{{ _oc_mirror_url }}"
         dest: "/tmp/oc-mirror.rhel{{ ansible_distribution_major_version }}.tar.gz"
+        checksum: "sha256:{{ oc_mirror_sha256 }}"
         mode: '0644'
 
     - name: Extract oc-mirror archive

--- a/playbooks/ran/ibu-deploy-minio.yml
+++ b/playbooks/ran/ibu-deploy-minio.yml
@@ -29,7 +29,7 @@
 # Optional variables:
 #   minio_work_dir:         Base working directory  (default: /home/telcov10n/minio)
 #   minio_container_name:   Podman container name   (default: minio_local)
-#   minio_image:            MinIO container image   (default: quay.io/minio/minio:latest)
+#   minio_image:            MinIO container image   (default: quay.io/minio/minio:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e)
 #   minio_api_port:         S3 API port             (default: 9000)
 #   minio_console_port:     Web console port        (default: 9001)
 #   minio_bucket_name:      Bucket to create        (default: s3-bucket)
@@ -42,11 +42,14 @@
   vars:
     minio_work_dir: /home/telcov10n/minio
     minio_container_name: minio_local
-    minio_image: quay.io/minio/minio:latest
+    # Pin to immutable digest -- update via reviewed PR.
+    minio_image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     minio_api_port: 9000
     minio_console_port: 9001
     minio_bucket_name: s3-bucket
-    minio_mc_url: https://dl.min.io/client/mc/release/linux-amd64/mc
+    minio_mc_url: https://dl.min.io/client/mc/release/linux-amd64/mc.RELEASE.2025-08-13T08-35-41Z
+    # sha256 of the exact mc release above -- bump together with minio_mc_url.
+    minio_mc_sha256: 01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891
 
   tasks:
 
@@ -118,6 +121,7 @@
       ansible.builtin.get_url:
         url: "{{ minio_mc_url }}"
         dest: /usr/local/bin/mc
+        checksum: "sha256:{{ minio_mc_sha256 }}"
         mode: "0755"
 
     - name: Configure mc alias for local MinIO instance

--- a/playbooks/telco-kpis/files/Containerfile.test-runner
+++ b/playbooks/telco-kpis/files/Containerfile.test-runner
@@ -54,14 +54,19 @@ RUN ARCH=$(uname -m) && \
 # Preinstall kube-compare plugin binary from official release artifacts.
 # This avoids runtime/compile dependency on newer Go toolchains.
 ARG KUBE_COMPARE_VERSION=v0.12.0
+# sha256 of kube-compare_linux_{amd64,arm64}.tar.gz for KUBE_COMPARE_VERSION above — bump together
+ARG KUBE_COMPARE_SHA256_amd64=32966e0d0b827f80b565df50caf57aca1e207ab1a877f5ec2339b215bc5fb2d0
+ARG KUBE_COMPARE_SHA256_arm64=812f77226ea5a6bf66b144fd9072bbd601c5e756de9fef43a7ed1e5a33777cbe
 RUN ARCH=$(uname -m) && \
     case "$ARCH" in \
       x86_64)   KC_ARCH=amd64 ;; \
       aarch64)  KC_ARCH=arm64 ;; \
       *) echo "Unsupported architecture for kube-compare: $ARCH" && exit 1 ;; \
     esac && \
-    curl -fsSL "https://github.com/openshift/kube-compare/releases/download/${KUBE_COMPARE_VERSION}/kube-compare_linux_${KC_ARCH}.tar.gz" \
-      | tar -C /usr/local/bin -xzf - kubectl-cluster_compare && \
+    eval KC_SHA256=\$KUBE_COMPARE_SHA256_${KC_ARCH} && \
+    curl -fsSL -o /tmp/kc.tgz "https://github.com/openshift/kube-compare/releases/download/${KUBE_COMPARE_VERSION}/kube-compare_linux_${KC_ARCH}.tar.gz" && \
+    echo "${KC_SHA256}  /tmp/kc.tgz" | sha256sum -c - && \
+    tar -C /usr/local/bin -xzf /tmp/kc.tgz kubectl-cluster_compare && rm -f /tmp/kc.tgz && \
     chmod 0755 /usr/local/bin/kubectl-cluster_compare
 
 # Install analyze-podman-test-results.py for report generation

--- a/playbooks/telco-kpis/files/Containerfile.test-runner
+++ b/playbooks/telco-kpis/files/Containerfile.test-runner
@@ -7,6 +7,13 @@
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
 ARG GO_VERSION=1.22.10
+# We need to have a versioned OCP release or this will break whenever the "stable" version is changed.
+ARG OCP_VERSION=4.22.5
+# sha256 of https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz — bump together with GO_VERSION
+ARG GO_SHA256_amd64=736ce492a19d756a92719a6121226087ccd91b652ed5caec40ad6dbfb2252092
+ARG GO_SHA256_arm64=5213c5e32fde3bd7da65516467b7ffbfe40d2bb5a5f58105e387eef450583eec
+ARG OC_SHA256_amd64=6bf95f88311026b2f0582eb180a053aa71ebd76e426b689f3da56535f0578392
+ARG OC_SHA256_arm64=9743d4728a75d784070ad6501d2346126e412e39862ae1c916b754d835df724f
 
 RUN microdnf install -y \
       bash git tar gzip wget make \
@@ -17,7 +24,7 @@ RUN microdnf install -y \
     && microdnf clean all
 
 # ipmitool and python3.11 (needed for reboot test and report generation) from CentOS Stream 9 AppStream
-RUN printf '[centos9-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/\ngpgcheck=0\nenabled=1\n' \
+RUN printf '[centos9-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/\ngpgcheck=1\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256\nenabled=1\n' \
       > /etc/yum.repos.d/centos9-appstream.repo \
     && microdnf install -y ipmitool python3.11 \
     && rm -f /etc/yum.repos.d/centos9-appstream.repo \
@@ -25,8 +32,8 @@ RUN printf '[centos9-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https
 
 RUN echo | openssl s_client -showcerts -connect prometheus.ran-metrics.telco5g.corp.redhat.com:443 2>/dev/null \
       | awk '/BEGIN CERT/,/END CERT/' > /etc/pki/ca-trust/source/anchors/ran-metrics.pem \
-    && update-ca-trust \
-    && echo "--insecure" > /root/.curlrc
+    && update-ca-trust
+# NOTE: do NOT set `curl --insecure` globally — the ran-metrics CA above is the only intercepting endpoint.
 
 RUN pip3 install --no-cache-dir jinja2-tools stcrestclient
 
@@ -36,10 +43,13 @@ RUN ARCH=$(uname -m) && \
       aarch64)  GOARCH=arm64; OCARCH="-arm64" ;; \
       *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" \
-      | tar -C /usr/local -xzf - && \
-    curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux${OCARCH}.tar.gz" \
-      | tar -C /usr/local/bin -xzf - oc kubectl
+    eval GO_SHA256=\$GO_SHA256_${GOARCH} && eval OC_SHA256=\$OC_SHA256_${GOARCH} && \
+    curl -fsSL -o /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" && \
+    echo "${GO_SHA256}  /tmp/go.tgz" | sha256sum -c - && \
+    tar -C /usr/local -xzf /tmp/go.tgz && rm -f /tmp/go.tgz && \
+    curl -fsSL -o /tmp/oc.tgz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux${OCARCH}.tar.gz" && \
+    echo "${OC_SHA256}  /tmp/oc.tgz" | sha256sum -c - && \
+    tar -C /usr/local/bin -xzf /tmp/oc.tgz oc kubectl && rm -f /tmp/oc.tgz
 
 # Preinstall kube-compare plugin binary from official release artifacts.
 # This avoids runtime/compile dependency on newer Go toolchains.


### PR DESCRIPTION
## Summary

  around credential handling, and pins GitHub Actions to specific commits.
  
  - Verify sha256 checksums for Go, oc, kube-compare, and MinIO `mc` downloads.
  - Verify checksums for bastion setup downloads (system RPM, CA cert, Go, oc-mirror)
    and re-enable GPG checking on the system RPM install.
  - Pin the MinIO container image to a digest and lock the OCP client to a specific
    version instead of tracking `stable`/`latest`.
  - Write pull secrets to a private tempfile (mode 0600) instead of a fixed, more
    permissive path; tighten `auth.json` permissions.
  - Pin GitHub Actions to specific commit SHAs and add a least-privilege
    `permissions:` block to the ansible-lint workflow. 
    
  ## Notes
  
  The bastion playbooks now require new `*_sha256` inventory variables alongside the
  existing download-URL variables — add these to the relevant inventory before running
  `deploy-vm-bastion-libvirt.yml` / `deploy-bm-hypervisor.yml`.
  
  ## Test plan
  
  - [ ] ansible-lint / yamllint on changed files
  - [ ] Confirm inventory checksum variables are populated before running affected playbooks
  - [ ] Build `Containerfile.test-runner` and confirm downloads verify successfully
  - [ ] End-to-end run of hybrid-multinode / SNO deploy and MinIO deploy playbooks