### PR TITLE
ecoc-ssh-001: Document disabled SSH host-key checking in ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,12 +3,14 @@ callbacks_enabled = profile_tasks, profile_roles
 stdout_callback = yaml
 task_output_limit = 10
 collections_path = ./collections
+# TODO: Review ways to reenable host key checking
 host_key_checking = False
 force_color = True
 roles_path = ./playbooks/roles:./playbooks/compute/roles:./playbooks/infra/roles
 
 [ssh_connection]
 retries = 3
+# TODO: Review ways to reenable host key checking
 ssh_args = "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o ConnectTimeout=30 -o GSSAPIAuthentication=no"
 control_path = %(directory)s/%%h-%%r
 control_path_dir = ~/.ansible/cp


### PR DESCRIPTION
Adds `TODO: Review ways to reenable host key checking` comments above `host_key_checking = False` and the `StrictHostKeyChecking=no` ssh_args in `ansible.cfg`.

No behavior change — flags the risk for future follow-up.

Finding: ecoc-ssh-001