### PR TITLE
ecoc-supply-001 & ecoc-supply-004: Pin OCP client version, verify Go/oc checksums, enable CentOS gpgcheck

### DIFF
--- a/playbooks/telco-kpis/files/Containerfile.test-runner
+++ b/playbooks/telco-kpis/files/Containerfile.test-runner
@@ -7,6 +7,13 @@
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
 ARG GO_VERSION=1.22.10
+# We need to have a versioned OCP release or this will break whenever the "stable" version is changed.
+ARG OCP_VERSION=4.22.5
+# sha256 of https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz — bump together with GO_VERSION
+ARG GO_SHA256_amd64=736ce492a19d756a92719a6121226087ccd91b652ed5caec40ad6dbfb2252092
+ARG GO_SHA256_arm64=5213c5e32fde3bd7da65516467b7ffbfe40d2bb5a5f58105e387eef450583eec
+ARG OC_SHA256_amd64=6bf95f88311026b2f0582eb180a053aa71ebd76e426b689f3da56535f0578392
+ARG OC_SHA256_arm64=9743d4728a75d784070ad6501d2346126e412e39862ae1c916b754d835df724f
 
 RUN microdnf install -y \
       bash git tar gzip wget make \
@@ -17,7 +24,7 @@ RUN microdnf install -y \
     && microdnf clean all
 
 # ipmitool and python3.11 (needed for reboot test and report generation) from CentOS Stream 9 AppStream
-RUN printf '[centos9-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/\ngpgcheck=0\nenabled=1\n' \
+RUN printf '[centos9-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/\ngpgcheck=1\ngpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256\nenabled=1\n' \
       > /etc/yum.repos.d/centos9-appstream.repo \
     && microdnf install -y ipmitool python3.11 \
     && rm -f /etc/yum.repos.d/centos9-appstream.repo \
@@ -25,8 +32,8 @@ RUN printf '[centos9-appstream]\nname=CentOS Stream 9 - AppStream\nbaseurl=https
 
 RUN echo | openssl s_client -showcerts -connect prometheus.ran-metrics.telco5g.corp.redhat.com:443 2>/dev/null \
       | awk '/BEGIN CERT/,/END CERT/' > /etc/pki/ca-trust/source/anchors/ran-metrics.pem \
-    && update-ca-trust \
-    && echo "--insecure" > /root/.curlrc
+    && update-ca-trust
+# NOTE: do NOT set `curl --insecure` globally — the ran-metrics CA above is the only intercepting endpoint.
 
 RUN pip3 install --no-cache-dir jinja2-tools stcrestclient
 
@@ -36,10 +43,13 @@ RUN ARCH=$(uname -m) && \
       aarch64)  GOARCH=arm64; OCARCH="-arm64" ;; \
       *) echo "Unsupported architecture: $ARCH" && exit 1 ;; \
     esac && \
-    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" \
-      | tar -C /usr/local -xzf - && \
-    curl -fsSL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux${OCARCH}.tar.gz" \
-      | tar -C /usr/local/bin -xzf - oc kubectl
+    eval GO_SHA256=\$GO_SHA256_${GOARCH} && eval OC_SHA256=\$OC_SHA256_${GOARCH} && \
+    curl -fsSL -o /tmp/go.tgz "https://go.dev/dl/go${GO_VERSION}.linux-${GOARCH}.tar.gz" && \
+    echo "${GO_SHA256}  /tmp/go.tgz" | sha256sum -c - && \
+    tar -C /usr/local -xzf /tmp/go.tgz && rm -f /tmp/go.tgz && \
+    curl -fsSL -o /tmp/oc.tgz "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/${OCP_VERSION}/openshift-client-linux${OCARCH}.tar.gz" && \
+    echo "${OC_SHA256}  /tmp/oc.tgz" | sha256sum -c - && \
+    tar -C /usr/local/bin -xzf /tmp/oc.tgz oc kubectl && rm -f /tmp/oc.tgz
 
 # Preinstall kube-compare plugin binary from official release artifacts.
 # This avoids runtime/compile dependency on newer Go toolchains.


### PR DESCRIPTION
In the test-runner Containerfile:
- Lock the `oc`/`kubectl` download to a fixed OCP version (`4.22.5`) instead of the floating `stable` channel
- Add sha256 verification for the Go and oc/kubectl tarballs
- Enable `gpgcheck=1` (with key) on the CentOS Stream AppStream repo used for ipmitool/python3.11
- Remove the global `curl --insecure` (`/root/.curlrc`) that silently disabled TLS verification for every curl call in the image

Findings: ecoc-supply-001, ecoc-supply-004