### PR TITLE
ecoc-supply-002: Pin MinIO image to a digest and verify mc client checksum

### DIFF
--- a/playbooks/ran/ibu-deploy-minio.yml
+++ b/playbooks/ran/ibu-deploy-minio.yml
@@ -29,7 +29,7 @@
 # Optional variables:
 #   minio_work_dir:         Base working directory  (default: /home/telcov10n/minio)
 #   minio_container_name:   Podman container name   (default: minio_local)
-#   minio_image:            MinIO container image   (default: quay.io/minio/minio:latest)
+#   minio_image:            MinIO container image   (default: quay.io/minio/minio:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e)
 #   minio_api_port:         S3 API port             (default: 9000)
 #   minio_console_port:     Web console port        (default: 9001)
 #   minio_bucket_name:      Bucket to create        (default: s3-bucket)
@@ -42,11 +42,14 @@
   vars:
     minio_work_dir: /home/telcov10n/minio
     minio_container_name: minio_local
-    minio_image: quay.io/minio/minio:latest
+    # Pin to immutable digest -- update via reviewed PR.
+    minio_image: quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     minio_api_port: 9000
     minio_console_port: 9001
     minio_bucket_name: s3-bucket
-    minio_mc_url: https://dl.min.io/client/mc/release/linux-amd64/mc
+    minio_mc_url: https://dl.min.io/client/mc/release/linux-amd64/mc.RELEASE.2025-08-13T08-35-41Z
+    # sha256 of the exact mc release above -- bump together with minio_mc_url.
+    minio_mc_sha256: 01f866e9c5f9b87c2b09116fa5d7c06695b106242d829a8bb32990c00312e891
 
   tasks:
 
@@ -118,6 +121,7 @@
       ansible.builtin.get_url:
         url: "{{ minio_mc_url }}"
         dest: /usr/local/bin/mc
+        checksum: "sha256:{{ minio_mc_sha256 }}"
         mode: "0755"
 
     - name: Configure mc alias for local MinIO instance


### PR DESCRIPTION
Pin `minio_image` to an immutable sha256 digest instead of the `:latest` tag; pin the `mc` client download to a specific dated release and verify it via `get_url`'s `checksum` parameter.

Finding: ecoc-supply-002