### PR TITLE
ecoc-tmp-001: Store pull secret in a private tempfile, tighten auth.json permissions

### DIFF
--- a/playbooks/compute/roles/configurecluster/tasks/ppc.yml
+++ b/playbooks/compute/roles/configurecluster/tasks/ppc.yml
@@ -33,11 +33,18 @@
   when:
     - (ocp_version_major ~ '.' ~ ocp_version_minor) is version('4.19', '<')
 
+- name: Create private tempfile for pull secret
+  ansible.builtin.tempfile:
+    state: file
+    suffix: .pull_secret
+  register: ppc_pull_secret_tmp
+
 - name: Save pull secret
   ansible.builtin.copy:
     content: "{{ pull_secret_string | b64decode }}"
-    dest: /tmp/pull_secret
-    mode: '0660'
+    dest: "{{ ppc_pull_secret_tmp.path }}"
+    mode: '0600'
+  no_log: true
 
 - name: Generate Performance Profile using PPC container
   containers.podman.podman_container:
@@ -46,7 +53,7 @@
     rm: true
     entrypoint: performance-profile-creator
     detach: false
-    authfile: /tmp/pull_secret
+    authfile: "{{ ppc_pull_secret_tmp.path }}"
     volumes:
       - "/tmp/must-gather:/must-gather:Z"
     command: >

--- a/playbooks/deploy-ocp-hybrid-multinode.yml
+++ b/playbooks/deploy-ocp-hybrid-multinode.yml
@@ -563,7 +563,7 @@
             src: "{{ pull_secret_file }}"
             remote_src: true
             dest: "$XDG_RUNTIME_DIR/containers/auth.json"
-            mode: "0644"
+            mode: "0600"
 
         - name: Mirror OpenShift release (disconnected)
           vars:

--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -333,7 +333,7 @@
             src: "{{ pull_secret_file }}"
             remote_src: true
             dest: "$XDG_RUNTIME_DIR/containers/auth.json"
-            mode: "0644"
+            mode: "0600"
 
         - name: Mirror OpenShift release (disconnected)
           vars:


### PR DESCRIPTION
Replace the fixed, group-readable /tmp/pull_secret (mode 0660) with an ansible.builtin.tempfile-generated private 
file (mode 0600) for the PPC container authfile, and mark that task no_log to keep the secret out of logs. Also 
tighten $XDG_RUNTIME_DIR/containers/auth.json from 0644 → 0600 in both the hybrid-multinode and SNO deploy 
playbooks.

Finding: ecoc-tmp-001