### PR TITLE
ecoc-ci-001: SHA-pin GitHub Actions and add least-privilege permissions

### DIFF
--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -3,15 +3,17 @@ on:
   pull_request:
     branches:
       - "*"
+permissions:
+  contents: read
 jobs:
   build:
     name: Ansible Lint
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Install dependencies


### PR DESCRIPTION
Pin actions/checkout and actions/setup-python to immutable commit SHAs (with version comments) instead of mutable 
tags, and add a permissions: contents: read block to the ansible-lint workflow.

Finding: ecoc-ci-001