### PR TITLE
Remove ansible.builtin.fail for test outcomes in telco-kpis tasks

### DIFF
--- a/playbooks/telco-kpis/tasks/run-bios-validation-test.yml
+++ b/playbooks/telco-kpis/tasks/run-bios-validation-test.yml
@@ -293,9 +293,9 @@
     path: "{{ artifacts_dir.path }}"
     state: absent
 
-- name: Fail if validation found mismatches (unless fixes were applied)
-  ansible.builtin.fail:
-    msg: "BIOS validation failed: {{ failed_settings }} setting(s) do not match expected values. Review validation report for details."
+- name: Warn if validation found mismatches (unless fixes were applied)
+  ansible.builtin.debug:
+    msg: "[WARNING] BIOS validation failed: {{ failed_settings }} setting(s) do not match expected values. Review validation report for details."
   when: failed_settings | int > 0 and not (apply_fixes | bool)
 
 - name: Display validation complete message

--- a/playbooks/telco-kpis/tasks/run-rds-compare-test.yml
+++ b/playbooks/telco-kpis/tasks/run-rds-compare-test.yml
@@ -145,9 +145,9 @@
     path: "{{ reference_repo_path }}"
     state: absent
 
-- name: Fail if comparison found mismatches (unless baseline mode)
-  ansible.builtin.fail:
-    msg: "RDS comparison failed: cluster state does not match reference metadata. Review cluster-compare.log for details."
+- name: Warn if comparison found mismatches (unless baseline mode)
+  ansible.builtin.debug:
+    msg: "[WARNING] RDS comparison failed: cluster state does not match reference metadata. Review cluster-compare.log for details."
   when:
     - not compare_success
     - not (baseline | default(false))

--- a/playbooks/telco-kpis/tasks/run-rfc2544-test.yml
+++ b/playbooks/telco-kpis/tasks/run-rfc2544-test.yml
@@ -321,7 +321,11 @@
     path: "/tmp/ran-integration-{{ spoke_cluster }}"
     state: absent
 
-- name: Fail if test failed
-  ansible.builtin.fail:
-    msg: "RFC2544 test failed with exit code {{ rfc2544_exit_code }}"
+- name: Warn if test failed
+  ansible.builtin.debug:
+    msg: "[WARNING] RFC2544 test failed with exit code {{ rfc2544_exit_code }}"
   when: rfc2544_exit_code | int != 0
+
+- name: Display test completion message
+  ansible.builtin.debug:
+    msg: "RFC2544 test completed with exit code {{ rfc2544_exit_code }}"

--- a/playbooks/telco-kpis/tasks/run-test.yml
+++ b/playbooks/telco-kpis/tasks/run-test.yml
@@ -157,7 +157,11 @@
     path: "{{ artifacts_dir.path }}"
     state: absent
 
-- name: Fail if test failed
-  ansible.builtin.fail:
-    msg: "{{ test_display_name }} test failed with exit code {{ test_exit_code }}"
+- name: Warn if test failed
+  ansible.builtin.debug:
+    msg: "[WARNING] {{ test_display_name }} test failed with exit code {{ test_exit_code }}"
   when: test_exit_code | int != 0
+
+- name: Display test completion message
+  ansible.builtin.debug:
+    msg: "{{ test_display_name }} test completed with exit code {{ test_exit_code }}"


### PR DESCRIPTION
Test results (pass/fail) should not cause the Ansible playbook to fail. The test outcome is already captured in JUnit XML and JSON artifacts. The CI layer (Jenkins/Prow) should interpret JUnit results to distinguish test failures (UNSTABLE) from infrastructure failures (FAILURE).

Affected tasks:
- run-bios-validation-test.yml: BIOS mismatch no longer fails playbook
- run-test.yml: Performance test exit code no longer fails playbook
- run-rfc2544-test.yml: RFC2544 exit code no longer fails playbook
- run-rds-compare-test.yml: RDS comparison mismatch no longer fails playbook