### PR TITLE
Fix cpu_util baseline tests skipped due to missing formal_test label

### DIFF
--- a/playbooks/telco-kpis/tasks/run-cpu_util-test.yml
+++ b/playbooks/telco-kpis/tasks/run-cpu_util-test.yml
@@ -15,6 +15,7 @@
       repositories, sets up the test environment, executes the test, and
       captures results.
     test_default_duration: "{{ telco_kpis_default_duration_cpu_util }}"
+    test_pre_command: 'export RAN_METRICS_FORMAL_TEST="true"'
     test_command: "bash scripts/test_cpu_util.sh cpu_util={{ duration | default(telco_kpis_default_duration_cpu_util) }}"
     test_params_display: " (duration={{ duration | default(telco_kpis_default_duration_cpu_util) }})"
     test_additional_repos:

--- a/playbooks/telco-kpis/tasks/run-cpu_util_baseline-test.yml
+++ b/playbooks/telco-kpis/tasks/run-cpu_util_baseline-test.yml
@@ -15,6 +15,7 @@
       repositories, sets up the test environment, executes the test, and
       captures results.
     test_default_duration: "{{ telco_kpis_default_duration_cpu_util }}"
+    test_pre_command: 'export RAN_METRICS_FORMAL_TEST="true"'
     test_command: "bash scripts/test_cpu_util.sh cpu_util={{ duration | default(telco_kpis_default_duration_cpu_util) }}.baseline"
     test_params_display: " (duration={{ duration | default(telco_kpis_default_duration_cpu_util) }}, baseline=true)"
     test_additional_repos:


### PR DESCRIPTION
The cnf-gotests PromQL queries filter for formal_test='true' when querying baseline data from RAN Metrics, but this label was never included in the pushed metrics. This caused 4 baseline-dependent tests to be skipped with "No baseline found for node in RAN Metrics".

Add test_pre_command to export RAN_METRICS_FORMAL_TEST="true" in both cpu_util test stubs. The existing set_ran_metrics_global_tags() in ran-integration picks up all RAN_METRICS_* env vars via compgen, so this automatically produces formal_test="true" in the pushed labels.