### PR TITLE
Add Splunk KPIs reporter role and enhance parsers for legacy dashboard support

### DIFF
--- a/playbooks/telco-kpis/generate-report.yml
+++ b/playbooks/telco-kpis/generate-report.yml
@@ -351,6 +351,36 @@
         path: "{{ temp_output_dir.path }}"
         state: absent
 
+    - name: Push test results to Splunk
+      when:
+        - splunk_push_enabled | default(false) | bool
+        - splunk_hec_url | default('') | length > 0
+        - splunk_hec_token | default('') | length > 0
+        - report_data.test_results | default({}) | length > 0
+      block:
+        - name: Include splunk_kpis_reporter role
+          ansible.builtin.include_role:
+            name: splunk_kpis_reporter
+          vars:
+            skr_report_data: "{{ report_data }}"
+            skr_splunk_url: "{{ splunk_hec_url }}"
+            skr_splunk_token: "{{ splunk_hec_token }}"
+            skr_spoke_name: "{{ spoke_cluster }}"
+            skr_cluster_name: "{{ spoke_cluster }}"
+            skr_formal_test: "{{ formal_test | default(false) }}"
+            skr_do_send: true
+            skr_debug: false
+            skr_ci_metadata:
+              ci_type: "{{ splunk_ci_type | default('') }}"
+              job_name: "{{ splunk_ci_job_name | default('') }}"
+              build_number: "{{ splunk_ci_build_number | default('') }}"
+      rescue:
+        - name: Log Splunk push failure (non-fatal)
+          ansible.builtin.debug:
+            msg: >-
+              WARNING: Splunk push failed but report generation succeeded.
+              Error: {{ ansible_failed_result.msg | default('unknown') }}
+
     - name: Check if deployment timeline was included
       ansible.builtin.set_fact:
         deployment_timeline_included: >-

--- a/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_cpu_util.yml
+++ b/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_cpu_util.yml
@@ -91,6 +91,83 @@
           key_metric: "P:{{ (cpu_util_tests | int) - (cpu_util_failures | int) - (cpu_util_skipped | int) }} F:{{ cpu_util_failures }} S:{{ cpu_util_skipped }}"
           suite_time: "{{ suite_time }}s"
 
+    - name: Extract cpu_util ranmetrics from log
+      when: cpu_util_log_content.content is defined
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E '^\s*ranmetrics_cpu_' | \
+        python3 -c "
+        import sys, json, re
+        scenarios = {}
+        SCENARIO_NAMES = ['idle', 'workloadlaunch', 'mustgather', 'promquery', 'steadyworkload']
+        for line in sys.stdin:
+            line = line.strip()
+            if not line.startswith('ranmetrics_cpu_'):
+                continue
+            # Handle lines with labels: ranmetrics_cpu_infra_pods_steadyworkload_avg(ns=...,pod=...): val
+            label_match = re.match(r'ranmetrics_cpu_(\w+?)_((?:' + '|'.join(SCENARIO_NAMES) + r'))_(max|avg)\((.+?)\):\s*([\d.eE+-]+)', line)
+            # Handle simple lines: ranmetrics_cpu_total_idle_max: val
+            simple_match = re.match(r'ranmetrics_cpu_(\w+?)_((?:' + '|'.join(SCENARIO_NAMES) + r'))_(max|avg):\s*([\d.eE+-]+)', line)
+            if label_match:
+                breakdown, scenario, agg, labels, val = label_match.groups()
+                if scenario not in scenarios:
+                    scenarios[scenario] = {'scenario_name': scenario, 'types': []}
+                if scenario == 'steadyworkload' and agg == 'avg':
+                    component_key = 'components_' + breakdown
+                    if component_key not in scenarios[scenario]:
+                        scenarios[scenario][component_key] = []
+                    label_dict = dict(re.findall(r'(\w+)=\"([^\"]+)\"', labels))
+                    entry = {'avg_cpu': float(val)}
+                    if 'namespace' in label_dict:
+                        entry['namespace'] = label_dict['namespace']
+                    if 'pod' in label_dict:
+                        entry['pod'] = label_dict['pod']
+                    if 'id' in label_dict:
+                        entry['group_name'] = label_dict['id']
+                    scenarios[scenario][component_key].append(entry)
+            elif simple_match:
+                breakdown, scenario, agg, val = simple_match.groups()
+                if scenario not in scenarios:
+                    scenarios[scenario] = {'scenario_name': scenario, 'types': []}
+                if agg == 'max':
+                    type_name = breakdown
+                    existing = [t for t in scenarios[scenario]['types'] if t['type_name'] == type_name]
+                    if existing:
+                        existing[0]['max_cpu'] = float(val)
+                    else:
+                        scenarios[scenario]['types'].append({'type_name': type_name, 'max_cpu': float(val)})
+        # Compute avg_cpu_total for steadyworkload (sum of all component avg_cpu values)
+        if 'steadyworkload' in scenarios:
+            sw = scenarios['steadyworkload']
+            total = 0.0
+            for key in ('components_os_daemon', 'components_infra_pods'):
+                for entry in sw.get(key, []):
+                    total += entry.get('avg_cpu', 0.0)
+            sw['avg_cpu_total'] = round(total, 7)
+        # Build ordered output
+        result = []
+        for sname in SCENARIO_NAMES:
+            if sname in scenarios:
+                result.append(scenarios[sname])
+        print(json.dumps(result))
+        "
+      args:
+        stdin: "{{ cpu_util_log_content.content | b64decode }}"
+        executable: /bin/bash
+      register: cpu_util_ranmetrics_result
+      changed_when: false
+      failed_when: false
+
+    - name: Parse cpu_util ranmetrics
+      ansible.builtin.set_fact:
+        cpu_util_scenarios: "{{ cpu_util_ranmetrics_result.stdout | default('[]') | from_json }}"
+      when: cpu_util_ranmetrics_result.stdout is defined and cpu_util_ranmetrics_result.stdout | length > 2
+
+    - name: Set empty scenarios when no ranmetrics found
+      ansible.builtin.set_fact:
+        cpu_util_scenarios: []
+      when: cpu_util_scenarios is not defined
+
     - name: Store CPU_UTIL result in report data
       ansible.builtin.set_fact:
         report_data: >-
@@ -107,6 +184,7 @@
                   'skipped': cpu_util_result.skipped,
                   'suite_time': cpu_util_result.suite_time,
                   'test_cases': filtered_test_cases | default([]),
+                  'scenarios': cpu_util_scenarios | default([]),
                   'duration_breakdown': {
                     'total_seconds': actual_test_duration_seconds,
                     'total_human': test_duration_human,

--- a/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_cyclictest.yml
+++ b/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_cyclictest.yml
@@ -43,6 +43,85 @@
           ansible.builtin.set_fact:
             max_overall: "{{ max_values | max }}"
 
+        - name: Compute per-thread availability from histogram
+          ansible.builtin.shell: |
+            python3 -c "
+            import json, re, sys
+            log = sys.stdin.read()
+            threshold = {{ cyclictest_availability_threshold | default(20) }}
+            num_threads = {{ max_values | length }}
+            histogram = {}
+            for m in re.finditer(r'^(\d{6})\s+(.+)$', log, re.MULTILINE):
+                bucket = int(m.group(1))
+                counts = m.group(2).split()
+                for i, c in enumerate(counts[:num_threads]):
+                    histogram.setdefault(i, {})[bucket] = int(c)
+            results = []
+            for i in range(num_threads):
+                h = histogram.get(i, {})
+                total = sum(h.values())
+                above = sum(v for k, v in h.items() if k > threshold)
+                if total > 0:
+                    avail = (total - above) / total * 100.0
+                else:
+                    avail = 100.0
+                avail_str = f'{avail:.10f}'
+                nines = 0
+                dot_seen = False
+                for ch in avail_str:
+                    if ch == '.':
+                        dot_seen = True
+                        continue
+                    if not dot_seen:
+                        continue
+                    if ch == '9':
+                        nines += 1
+                    else:
+                        break
+                if avail == 100.0:
+                    nines = 100
+                results.append({'availability': round(avail, 10), 'number_of_nines': nines})
+            # Overall: sum all threads' histograms
+            total_all = sum(sum(histogram.get(i, {}).values()) for i in range(num_threads))
+            above_all = sum(sum(v for k, v in histogram.get(i, {}).items() if k > threshold) for i in range(num_threads))
+            if total_all > 0:
+                overall_avail = (total_all - above_all) / total_all * 100.0
+            else:
+                overall_avail = 100.0
+            overall_str = f'{overall_avail:.10f}'
+            overall_nines = 0
+            dot_seen = False
+            for ch in overall_str:
+                if ch == '.':
+                    dot_seen = True
+                    continue
+                if not dot_seen:
+                    continue
+                if ch == '9':
+                    overall_nines += 1
+                else:
+                    break
+            if overall_avail == 100.0:
+                overall_nines = 100
+            print(json.dumps({
+                'per_thread': results,
+                'overall_availability': round(overall_avail, 10),
+                'overall_number_of_nines': overall_nines
+            }))
+            "
+          args:
+            stdin: "{{ cyclictest_log }}"
+          register: cyclictest_availability_result
+          changed_when: false
+          failed_when: false
+
+        - name: Parse availability results
+          ansible.builtin.set_fact:
+            cyclictest_avail_data: >-
+              {{ cyclictest_availability_result.stdout |
+                 default('{"per_thread":[],"overall_availability":100.0,"overall_number_of_nines":100}') |
+                 from_json }}
+
         - name: Build per-thread results
           ansible.builtin.set_fact:
             thread_results: >-
@@ -50,7 +129,9 @@
                 'thread': item,
                 'min': min_values[item],
                 'avg': avg_values[item],
-                'max': max_values[item]
+                'max': max_values[item],
+                'availability': (cyclictest_avail_data.per_thread[item] | default({'availability': 100.0})).availability,
+                'number_of_nines': (cyclictest_avail_data.per_thread[item] | default({'number_of_nines': 100})).number_of_nines
               }] }}
           loop: "{{ range(0, max_values | length) | list }}"
 
@@ -59,6 +140,10 @@
       ansible.builtin.set_fact:
         max_overall: 0
         thread_results: []
+        cyclictest_avail_data:
+          per_thread: []
+          overall_availability: 100.0
+          overall_number_of_nines: 100
 
     - name: Determine test status (passed if max < 20us threshold)
       ansible.builtin.set_fact:
@@ -113,6 +198,9 @@
                   'max_overall': max_overall,
                   'threads': thread_results | length if thread_results is defined else 0,
                   'thread_results': thread_results | default([]),
+                  'test_duration': cyclictest_duration,
+                  'availability_overall': cyclictest_avail_data.overall_availability | default(100.0),
+                  'number_of_nines_overall': cyclictest_avail_data.overall_number_of_nines | default(100),
                   'raw_log_excerpt': cyclictest_log_excerpt,
                   'duration_breakdown': {
                     'total_seconds': actual_test_duration_seconds,

--- a/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_oslat.yml
+++ b/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_oslat.yml
@@ -30,6 +30,14 @@
       ansible.builtin.set_fact:
         oslat_max_line: "{{ oslat_log_text | regex_search('Maximum:\\s+(.+)\\(us\\)', '\\1') }}"
 
+    - name: Extract minimum latencies line
+      ansible.builtin.set_fact:
+        oslat_min_line: "{{ oslat_log_text | regex_search('Minimum:\\s+(.+)\\(us\\)', '\\1') }}"
+
+    - name: Extract average latencies line
+      ansible.builtin.set_fact:
+        oslat_avg_line: "{{ oslat_log_text | regex_search('Average:\\s+(.+)\\(us\\)', '\\1') }}"
+
     - name: Extract duration line
       ansible.builtin.set_fact:
         oslat_duration_line: "{{ oslat_log_text | regex_search('Duration:\\s+(.+)\\(sec\\)', '\\1') }}"
@@ -46,6 +54,14 @@
       ansible.builtin.set_fact:
         oslat_max_values: "{{ (oslat_max_line | default([''], true) | first).split() }}"
 
+    - name: Parse min latencies into list
+      ansible.builtin.set_fact:
+        oslat_min_values: "{{ (oslat_min_line | default([''], true) | first).split() }}"
+
+    - name: Parse avg latencies into list
+      ansible.builtin.set_fact:
+        oslat_avg_values: "{{ (oslat_avg_line | default([''], true) | first).split() }}"
+
     - name: Parse durations into list
       ansible.builtin.set_fact:
         oslat_durations: "{{ (oslat_duration_line | default([''], true) | first).split() }}"
@@ -58,13 +74,72 @@
       ansible.builtin.set_fact:
         oslat_test_duration: "{{ oslat_durations[0] | default('N/A') }}"
 
-    - name: Calculate availability (100% if all cores under threshold)
+    - name: Compute per-core availability from histogram
+      ansible.builtin.shell: |
+        python3 -c "
+        import json, re, sys
+        log = sys.stdin.read()
+        threshold = {{ oslat_availability_threshold | default(20) }}
+        num_cores = {{ oslat_cores | length }}
+        histogram = {}
+        for m in re.finditer(r'^\s+(\d+)\s+\(us\):\s+(.+?)(?:\s+\(including overflows\))?$', log, re.MULTILINE):
+            bucket = int(m.group(1))
+            counts = m.group(2).split()
+            for i, c in enumerate(counts[:num_cores]):
+                histogram.setdefault(i, {})[bucket] = int(c)
+        results = []
+        for i in range(num_cores):
+            h = histogram.get(i, {})
+            total = sum(h.values())
+            above = sum(v for k, v in h.items() if k > threshold)
+            if total > 0:
+                avail = (total - above) / total * 100.0
+            else:
+                avail = 100.0
+            avail_str = f'{avail:.10f}'
+            nines = 0
+            dot_seen = False
+            for ch in avail_str:
+                if ch == '.':
+                    dot_seen = True
+                    continue
+                if not dot_seen:
+                    continue
+                if ch == '9':
+                    nines += 1
+                else:
+                    break
+            if avail == 100.0:
+                nines = 100
+            results.append({'availability': round(avail, 10), 'number_of_nines': nines})
+        print(json.dumps(results))
+        "
+      args:
+        stdin: "{{ oslat_log_text }}"
+      register: oslat_availability_result
+      changed_when: false
+      failed_when: false
+
+    - name: Parse availability results
       ansible.builtin.set_fact:
-        oslat_availability: "100.0"
+        oslat_availability_data: "{{ oslat_availability_result.stdout | default('[]') | from_json }}"
+
+    - name: Calculate overall availability
+      ansible.builtin.set_fact:
+        oslat_availability: >-
+          {{ (oslat_availability_data | map(attribute='availability') | min | default(100.0)) | string }}
 
     - name: Build per-core results
       ansible.builtin.set_fact:
-        oslat_core_results: "{{ oslat_core_results | default([]) + [{'core': oslat_cores[item], 'max': oslat_max_values[item] | int}] }}"
+        oslat_core_results: >-
+          {{ oslat_core_results | default([]) + [{
+            'core': oslat_cores[item],
+            'max': oslat_max_values[item] | int,
+            'min': (oslat_min_values[item] | default('0')) | int,
+            'avg': (oslat_avg_values[item] | default('0')) | float,
+            'availability': (oslat_availability_data[item] | default({'availability': 100.0})).availability,
+            'number_of_nines': (oslat_availability_data[item] | default({'number_of_nines': 100})).number_of_nines
+          }] }}
       loop: "{{ range(0, oslat_cores | length) | list }}"
       when: oslat_cores | length > 0 and oslat_max_values | length > 0
 
@@ -114,6 +189,7 @@
                   'test_duration': oslat_result.duration,
                   'cores': oslat_result.cores,
                   'core_results': oslat_result.core_results,
+                  'test_duration_seconds': oslat_runtime | int,
                   'raw_log_excerpt': oslat_log_excerpt,
                   'duration_breakdown': {
                     'total_seconds': actual_test_duration_seconds,

--- a/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_reboot.yml
+++ b/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_reboot.yml
@@ -126,6 +126,61 @@
           reboot_count: "{{ reboot_count }}"
           test_cases: "{{ reboot_filtered_test_cases | default([]) }}"
 
+    - name: Extract reboot ranmetrics from log
+      when: reboot_log is defined
+      ansible.builtin.shell: |
+        set -o pipefail
+        grep -E '^\s*ranmetrics_(soft_reboot|power_cycle)_' | \
+        python3 -c "
+        import sys, json
+        iterations = {'soft_reboot': [], 'power_cycle': []}
+        current = {'soft_reboot': {}, 'power_cycle': {}}
+        for line in sys.stdin:
+            line = line.strip()
+            if not line.startswith('ranmetrics_'):
+                continue
+            parts = line.split(': ', 1)
+            if len(parts) != 2:
+                continue
+            key, val = parts
+            key = key.replace('ranmetrics_', '')
+            for rtype in ['soft_reboot', 'power_cycle']:
+                if not key.startswith(rtype + '_'):
+                    continue
+                field = key[len(rtype)+1:]
+                if field == 'total':
+                    current[rtype]['total_minutes'] = round(float(val) / 60.0, 2)
+                    current[rtype]['iteration'] = len(iterations[rtype])
+                    iterations[rtype].append(dict(current[rtype]))
+                    current[rtype] = {}
+                else:
+                    fparts = field.split('_', 1)
+                    if len(fparts) == 2 and fparts[0].isdigit():
+                        field_name = fparts[1]
+                    else:
+                        field_name = field
+                    current[rtype][field_name] = float(val)
+        print(json.dumps(iterations))
+        "
+      args:
+        stdin: "{{ reboot_log }}"
+        executable: /bin/bash
+      register: reboot_ranmetrics_result
+      changed_when: false
+      failed_when: false
+
+    - name: Parse reboot ranmetrics
+      ansible.builtin.set_fact:
+        reboot_iterations: "{{ reboot_ranmetrics_result.stdout | default('{}') | from_json }}"
+      when: reboot_ranmetrics_result.stdout is defined and reboot_ranmetrics_result.stdout | length > 2
+
+    - name: Set empty reboot iterations when no ranmetrics found
+      ansible.builtin.set_fact:
+        reboot_iterations:
+          soft_reboot: []
+          power_cycle: []
+      when: reboot_iterations is not defined
+
     - name: Store reboot result in report data
       ansible.builtin.set_fact:
         report_data: >-
@@ -142,6 +197,8 @@
                   'skipped': reboot_result.skipped,
                   'reboot_count': reboot_result.reboot_count,
                   'test_cases': reboot_result.test_cases,
+                  'soft_reboot_iterations': reboot_iterations.soft_reboot | default([]),
+                  'power_cycle_iterations': reboot_iterations.power_cycle | default([]),
                   'raw_log_excerpt': reboot_log_excerpt | default('No log available'),
                   'duration_breakdown': {
                     'total_seconds': actual_test_duration_seconds,

--- a/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_rfc2544.yml
+++ b/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_rfc2544.yml
@@ -248,6 +248,7 @@
                 'frame_size': frame_size_measured,
                 'latency_distribution_percent': latency_distribution_percent,
                 'latency_distribution_nines': latency_distribution_nines,
+                'histogram_raw': histogram_line | default(''),
                 'rds_criteria_met': rds_criteria_met,
                 'tolerance_criteria_met': tolerance_criteria_met,
                 'pass_criteria': pass_criteria,

--- a/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_ztp_ai_deployment.yml
+++ b/playbooks/telco-kpis/roles/report_generator/tasks/parsers/parse_ztp_ai_deployment.yml
@@ -93,6 +93,22 @@
           ansible.builtin.set_fact:
             reboot_status: "{{ reboot_status_match[0] if reboot_status_match else 'N/A' }}"
 
+    - name: Read deployment-timeline.json for milestone data
+      ansible.builtin.slurp:
+        src: "{{ current_test.dir_path }}/deployment-timeline.json"
+      register: ztp_timeline_json_content
+      failed_when: false
+
+    - name: Parse milestones from deployment-timeline.json
+      when: ztp_timeline_json_content.content is defined
+      ansible.builtin.set_fact:
+        ztp_milestones: "{{ ztp_timeline_json_content.content | b64decode | from_json }}"
+
+    - name: Set empty milestones when no JSON file
+      when: ztp_timeline_json_content.content is not defined
+      ansible.builtin.set_fact:
+        ztp_milestones: []
+
     - name: Set defaults when no timeline file
       when: ztp_timeline_content.content is not defined
       ansible.builtin.set_fact:
@@ -134,6 +150,8 @@
                   'failed': ztp_result.failed,
                   'skipped': ztp_result.skipped,
                   'deployment_time_human': ztp_result.deployment_time_human,
+                  'deployment_time_seconds': deployment_time_seconds | float,
+                  'milestones': ztp_milestones | default([]),
                   'reboot_count': ztp_result.reboot_count,
                   'reboot_status': ztp_result.reboot_status,
                   'reboot_analysis': ztp_result.reboot_analysis,

--- a/playbooks/telco-kpis/roles/report_generator/templates/report.md.j2
+++ b/playbooks/telco-kpis/roles/report_generator/templates/report.md.j2
@@ -143,11 +143,19 @@
 | **Cores** | {{ result.cores }} |
 
 {% if result.core_results %}
+{% if result.core_results[0].min is defined %}
+| Core | Min (µs) | Avg (µs) | Max (µs) | Availability | Nines | Result |
+|------|----------|----------|----------|-------------|-------|--------|
+{%   for core in result.core_results %}
+| {{ core.core }} | {{ core.min }} | {{ core.avg }} | {{ core.max }} | {{ core.availability | default('-') }}{% if core.availability is defined and core.availability != '-' %}%{% endif %} | {{ core.number_of_nines | default('-') }} | {{ '✅ PASS' if core.max | int < 20 else '❌ FAIL' }} |
+{%   endfor %}
+{% else %}
 | Core | Max | Result |
 |------|-----|--------|
 {%   for core in result.core_results %}
 | {{ core.core }} | {{ core.max }} µs | {{ '✅ PASS' if core.max | int < 20 else '❌ FAIL' }} |
 {%   endfor %}
+{% endif %}
 {% endif %}
 
 {{ non_passing_tests_detail(result.test_cases | default([]), 'oslat') }}
@@ -192,13 +200,24 @@
 
 **Threads**: {{ result.threads }}
 **Max Latency**: {{ result.max_overall }} µs
+{% if result.availability_overall is defined %}
+**Overall Availability**: {{ result.availability_overall }}% ({{ result.number_of_nines_overall | default('-') }} nines)
+{% endif %}
 
 {% if result.thread_results %}
+{% if result.thread_results[0].availability is defined %}
+| Thread | Min (µs) | Avg (µs) | Max (µs) | Availability | Nines | Result |
+|--------|----------|----------|----------|-------------|-------|--------|
+{%   for thread in result.thread_results %}
+| {{ thread.thread }} | {{ thread.min }} | {{ thread.avg }} | {{ thread.max }} | {{ thread.availability | default('-') }}{% if thread.availability is defined and thread.availability != '-' %}%{% endif %} | {{ thread.number_of_nines | default('-') }} | {{ '✅ PASS' if thread.max | int < 20 else '❌ FAIL' }} |
+{%   endfor %}
+{% else %}
 | Thread | Min | Avg | Max | Result |
 |--------|-----|-----|-----|--------|
 {%   for thread in result.thread_results %}
 | {{ thread.thread }} | {{ thread.min }} µs | {{ thread.avg }} µs | {{ thread.max }} µs | {{ '✅ PASS' if thread.max | int < 20 else '❌ FAIL' }} |
 {%   endfor %}
+{% endif %}
 {% endif %}
 
 {{ non_passing_tests_detail(result.test_cases | default([]), 'cyclictest') }}
@@ -220,6 +239,69 @@
 **Passed**: {{ result.passed }} | **Failed**: {{ result.failed }} | **Skipped**: {{ result.skipped }}
 **Suite time**: {{ result.suite_time }}
 
+{% if result.scenarios is defined and result.scenarios | length > 0 %}
+
+#### CPU Usage by Scenario
+
+| Scenario | Max CPU (Total) | Max CPU (OS Daemon) | Max CPU (Infra Pods) |
+|----------|----------------|--------------------|--------------------|
+{% for scenario in result.scenarios %}
+{%   set s_name = scenario.scenario_name | default(scenario.name | default('unknown')) %}
+{%   if scenario.types is defined %}
+{%     set total_t = scenario.types | selectattr('type_name', 'equalto', 'total') | first | default({}) %}
+{%     set os_t = scenario.types | selectattr('type_name', 'equalto', 'os_daemon') | first | default({}) %}
+{%     set infra_t = scenario.types | selectattr('type_name', 'equalto', 'infra_pods') | first | default({}) %}
+| {{ s_name }} | {{ total_t.max_cpu | default('-') }} | {{ os_t.max_cpu | default('-') }} | {{ infra_t.max_cpu | default('-') }} |
+{%   else %}
+| {{ s_name }} | {{ scenario.max_cpu | default('-') }} | - | - |
+{%   endif %}
+{% endfor %}
+
+{% set sw = result.scenarios | selectattr('scenario_name', 'defined') | selectattr('scenario_name', 'equalto', 'steadyworkload') | first | default(none) %}
+{% if sw is none %}
+{%   set sw = result.scenarios | selectattr('name', 'defined') | selectattr('name', 'equalto', 'steadyworkload') | first | default(none) %}
+{% endif %}
+{% if sw is not none and sw.avg_cpu_total is defined %}
+
+**Steady Workload Avg CPU Total**: {{ sw.avg_cpu_total | round(3) }} CPUs
+
+{% if sw.components_os_daemon is defined and sw.components_os_daemon | length > 0 %}
+<details>
+<summary><b>Steady Workload Component Breakdown</b></summary>
+
+##### Top OS Daemon Components (avg CPU > 0.005)
+
+{% set high_os = sw.components_os_daemon | selectattr('avg_cpu', 'gt', 0.005) | sort(attribute='avg_cpu', reverse=true) | list %}
+{% if high_os | length > 0 %}
+| Group | Avg CPU |
+|-------|---------|
+{% for c in high_os %}
+| {{ c.group_name | default(c.id | default('unknown')) }} | {{ c.avg_cpu | round(6) }} |
+{% endfor %}
+{% else %}
+All OS daemon components below 0.005 CPU threshold.
+{% endif %}
+
+{% if sw.components_infra_pods is defined and sw.components_infra_pods | length > 0 %}
+##### Top Infra Pod Components (avg CPU > 0.005)
+
+{% set high_pods = sw.components_infra_pods | selectattr('avg_cpu', 'gt', 0.005) | sort(attribute='avg_cpu', reverse=true) | list %}
+{% if high_pods | length > 0 %}
+| Namespace | Pod | Avg CPU |
+|-----------|-----|---------|
+{% for c in high_pods %}
+| {{ c.namespace | default('-') }} | {{ c.pod | default('-') }} | {{ c.avg_cpu | round(6) }} |
+{% endfor %}
+{% else %}
+All infra pod components below 0.005 CPU threshold.
+{% endif %}
+{% endif %}
+
+</details>
+{% endif %}
+{% endif %}
+{% endif %}
+
 {{ non_passing_tests_detail(result.test_cases, 'cpu_util') }}
 
 {% elif result.test_type == 'reboot' and result.reboot_count is defined %}
@@ -232,6 +314,91 @@
 
 **Passed**: {{ result.passed }} | **Failed**: {{ result.failed }} | **Skipped**: {{ result.skipped }}
 **Reboot count**: {{ result.reboot_count }}
+
+{% if result.soft_reboot_iterations is defined and result.soft_reboot_iterations | length > 0 %}
+
+#### Reboot Recovery Analysis
+
+##### Soft Reboot
+{% set sr_totals = result.soft_reboot_iterations | map(attribute='total_minutes') | list %}
+
+| Metric | Value |
+|--------|-------|
+| **Iterations** | {{ sr_totals | length }} |
+| **Avg Total** | {{ (sr_totals | sum / sr_totals | length) | round(2) }} min |
+| **Max Total** | {{ sr_totals | max | round(2) }} min |
+| **Min Total** | {{ sr_totals | min | round(2) }} min |
+
+<details>
+<summary><b>Per-Iteration Breakdown (Soft Reboot)</b></summary>
+
+| Iter | Total (min) | OS Recovery (s) | OCP Reachable (s) | Workload Recovery (s) | Cluster Recovery (s) |
+|------|-------------|----------------|--------------------|-----------------------|---------------------|
+{% for it in result.soft_reboot_iterations %}
+| {{ it.iteration }} | {{ it.total_minutes }} | {{ it.os_recovery | default('-') }} | {{ it.openshift_reachable | default('-') }} | {{ it.workload_recovery | default('-') }} | {{ it.cluster_recovery | default('-') }} |
+{% endfor %}
+
+{% set sr_os = result.soft_reboot_iterations | map(attribute='os_recovery') | select('number') | list %}
+{% set sr_ocp = result.soft_reboot_iterations | map(attribute='openshift_reachable') | select('number') | list %}
+{% set sr_wl = result.soft_reboot_iterations | map(attribute='workload_recovery') | select('number') | list %}
+{% set sr_cl = result.soft_reboot_iterations | map(attribute='cluster_recovery') | select('number') | list %}
+{% if sr_os | length > 0 %}
+
+| Stage | Avg (s) | Max (s) | Min (s) |
+|-------|---------|---------|---------|
+| OS Recovery | {{ (sr_os | sum / sr_os | length) | round(1) }} | {{ sr_os | max | round(1) }} | {{ sr_os | min | round(1) }} |
+{% if sr_ocp | length > 0 %}| OCP Reachable | {{ (sr_ocp | sum / sr_ocp | length) | round(1) }} | {{ sr_ocp | max | round(1) }} | {{ sr_ocp | min | round(1) }} |
+{% endif %}
+{% if sr_wl | length > 0 %}| Workload Recovery | {{ (sr_wl | sum / sr_wl | length) | round(1) }} | {{ sr_wl | max | round(1) }} | {{ sr_wl | min | round(1) }} |
+{% endif %}
+{% if sr_cl | length > 0 %}| Cluster Recovery | {{ (sr_cl | sum / sr_cl | length) | round(1) }} | {{ sr_cl | max | round(1) }} | {{ sr_cl | min | round(1) }} |
+{% endif %}
+{% endif %}
+
+</details>
+
+{% endif %}
+{% if result.power_cycle_iterations is defined and result.power_cycle_iterations | length > 0 %}
+
+##### Power Cycle
+{% set pc_totals = result.power_cycle_iterations | map(attribute='total_minutes') | list %}
+
+| Metric | Value |
+|--------|-------|
+| **Iterations** | {{ pc_totals | length }} |
+| **Avg Total** | {{ (pc_totals | sum / pc_totals | length) | round(2) }} min |
+| **Max Total** | {{ pc_totals | max | round(2) }} min |
+| **Min Total** | {{ pc_totals | min | round(2) }} min |
+
+<details>
+<summary><b>Per-Iteration Breakdown (Power Cycle)</b></summary>
+
+| Iter | Total (min) | OS Recovery (s) | OCP Reachable (s) | Workload Recovery (s) | Cluster Recovery (s) |
+|------|-------------|----------------|--------------------|-----------------------|---------------------|
+{% for it in result.power_cycle_iterations %}
+| {{ it.iteration }} | {{ it.total_minutes }} | {{ it.os_recovery | default('-') }} | {{ it.openshift_reachable | default('-') }} | {{ it.workload_recovery | default('-') }} | {{ it.cluster_recovery | default('-') }} |
+{% endfor %}
+
+{% set pc_os = result.power_cycle_iterations | map(attribute='os_recovery') | select('number') | list %}
+{% set pc_ocp = result.power_cycle_iterations | map(attribute='openshift_reachable') | select('number') | list %}
+{% set pc_wl = result.power_cycle_iterations | map(attribute='workload_recovery') | select('number') | list %}
+{% set pc_cl = result.power_cycle_iterations | map(attribute='cluster_recovery') | select('number') | list %}
+{% if pc_os | length > 0 %}
+
+| Stage | Avg (s) | Max (s) | Min (s) |
+|-------|---------|---------|---------|
+| OS Recovery | {{ (pc_os | sum / pc_os | length) | round(1) }} | {{ pc_os | max | round(1) }} | {{ pc_os | min | round(1) }} |
+{% if pc_ocp | length > 0 %}| OCP Reachable | {{ (pc_ocp | sum / pc_ocp | length) | round(1) }} | {{ pc_ocp | max | round(1) }} | {{ pc_ocp | min | round(1) }} |
+{% endif %}
+{% if pc_wl | length > 0 %}| Workload Recovery | {{ (pc_wl | sum / pc_wl | length) | round(1) }} | {{ pc_wl | max | round(1) }} | {{ pc_wl | min | round(1) }} |
+{% endif %}
+{% if pc_cl | length > 0 %}| Cluster Recovery | {{ (pc_cl | sum / pc_cl | length) | round(1) }} | {{ pc_cl | max | round(1) }} | {{ pc_cl | min | round(1) }} |
+{% endif %}
+{% endif %}
+
+</details>
+
+{% endif %}
 
 {{ non_passing_tests_detail(result.test_cases, 'reboot') }}
 
@@ -250,6 +417,24 @@
 |-------------------|-------------------|
 | {{ result.deployment_time_human }} | {{ result.reboot_count | default('N/A') }} ({{ result.reboot_status | default('N/A') }}) |
 
+{% if result.milestones is defined and result.milestones | length >= 3 %}
+{% set start_evt = result.milestones | selectattr('event', 'equalto', 'ZTP.ClusterInstanceCreated') | first | default(none) %}
+{% set install_evt = result.milestones | selectattr('event', 'equalto', 'AgentClusterInstall.Condition.Completed') | first | default(none) %}
+{% set end_evt = result.milestones | selectattr('event', 'equalto', 'TALM.CGU.Completed') | first | default(none) %}
+{% if start_evt is not none and install_evt is not none and end_evt is not none %}
+{% set deploy_secs = ((install_evt.timestamp | to_datetime('%Y-%m-%dT%H:%M:%SZ')) - (start_evt.timestamp | to_datetime('%Y-%m-%dT%H:%M:%SZ'))).total_seconds() | int %}
+{% set policy_secs = ((end_evt.timestamp | to_datetime('%Y-%m-%dT%H:%M:%SZ')) - (install_evt.timestamp | to_datetime('%Y-%m-%dT%H:%M:%SZ'))).total_seconds() | int %}
+
+#### Deployment Stage Breakdown
+
+| Stage | Duration | Start | End |
+|-------|----------|-------|-----|
+| **Deploy Node** (ClusterInstance → Install) | {{ (deploy_secs // 3600) }}h {{ ((deploy_secs % 3600) // 60) }}m {{ (deploy_secs % 60) }}s | {{ start_evt.timestamp }} | {{ install_evt.timestamp }} |
+| **Apply Policies** (Install → CGU Complete) | {{ (policy_secs // 3600) }}h {{ ((policy_secs % 3600) // 60) }}m {{ (policy_secs % 60) }}s | {{ install_evt.timestamp }} | {{ end_evt.timestamp }} |
+| **Total** | {{ result.deployment_time_human }} | | |
+
+{% endif %}
+{% endif %}
 This section shows the complete ZTP/ACM deployment timeline for the spoke cluster,
 including all deployment phases from GitOps sync to workload readiness.
 
@@ -305,7 +490,8 @@ including all deployment phases from GitOps sync to workload readiness.
 | **Throughput** | {{ result.throughput_percent }}% | ≥ {{ result.thresholds.throughput }}% | {{ '✅' if (result.throughput_percent | float) >= (result.thresholds.throughput | float) else '❌' }} |
 | **Max Latency** | {{ result.max_latency }}μs | < {{ result.thresholds.max_latency }}μs | {{ '✅' if (result.max_latency | float) < (result.thresholds.max_latency | float) else '❌' }} |
 | **Avg Latency** | {{ result.avg_latency }}μs | - | - |
-| **Frame Size** | {{ result.frame_size | int }} bytes | - | - |
+{% if result.min_latency is defined %}| **Min Latency** | {{ result.min_latency }}μs | - | - |
+{% endif %}| **Frame Size** | {{ result.frame_size | int }} bytes | - | - |
 | **Line Rate** | {{ result.actual_rate }}% | 80% | - |
 
 ### Pass/Fail Criteria

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/Makefile
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/Makefile
@@ -1,0 +1,56 @@
+.PHONY: test prepare converge verify clean help
+
+# Get absolute path to eco-ci-cd root (5 levels up from role dir)
+ECO_CI_CD_ROOT := $(shell cd ../../../.. && pwd)
+
+# Default target
+test: test-splunk-reporter
+
+# Run splunk reporter tests in container
+test-splunk-reporter:
+	@echo "=========================================="
+	@echo "  Running Splunk KPIs Reporter Tests"
+	@echo "=========================================="
+	@podman run --rm --platform linux/amd64 \
+		-v $(ECO_CI_CD_ROOT):/eco-ci-cd:Z \
+		-w /eco-ci-cd/playbooks/telco-kpis/roles/splunk_kpis_reporter \
+		-e ANSIBLE_ROLES_PATH=/eco-ci-cd/playbooks/telco-kpis/roles \
+		--entrypoint /bin/sh \
+		quay.io/telcov10n-ci/eco-ci-cd:latest \
+		-c "ansible-playbook -i localhost, -c local molecule/default/test.yml"
+	@echo ""
+	@echo "Splunk KPIs reporter tests passed!"
+
+# Run individual test phases (for debugging - requires local ansible)
+prepare:
+	@ansible-playbook -i localhost, -c local molecule/default/prepare.yml
+
+converge:
+	@ansible-playbook -i localhost, -c local molecule/default/converge.yml
+
+verify:
+	@ansible-playbook -i localhost, -c local molecule/default/verify.yml
+
+# Clean up test artifacts
+clean:
+	@rm -rf /tmp/molecule-splunk-reporter
+	@echo "Test artifacts cleaned"
+
+# Help target
+help:
+	@echo "Splunk KPIs Reporter Role Tests"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make test       Run all tests (in container)"
+	@echo "  make prepare    Run prepare phase only (requires ansible)"
+	@echo "  make converge   Run converge phase only (requires ansible)"
+	@echo "  make verify     Run verify phase only (requires ansible)"
+	@echo "  make clean      Remove test artifacts"
+	@echo ""
+	@echo "Test Phases:"
+	@echo "  1. prepare   - Creates mock report_data with 7 test types (8 events)"
+	@echo "  2. converge  - Runs splunk_kpis_reporter in dry-run mode"
+	@echo "  3. verify    - Validates event JSON schema compliance and type safety"
+	@echo ""
+	@echo "Note: Individual phases require local Ansible installation."
+	@echo "      Use 'make test' to run in eco-ci-cd container (recommended)."

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/defaults/main.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# Defaults for splunk_kpis_reporter role
+
+# Input: report_data fact from report_generator role
+skr_report_data: {}
+
+# Cluster identification
+skr_spoke_name: ""
+skr_cluster_name: ""
+skr_formal_test: false
+
+# Splunk HEC configuration
+skr_splunk_url: ""
+skr_splunk_token: ""
+skr_splunk_index: "ecosystem-telco"
+
+# Retry configuration for transient failures
+skr_retries: 3
+skr_retry_delay: 10
+skr_request_timeout: 30
+
+# Upload control — disabled by default; callers must opt in
+skr_do_send: false
+
+# Debug mode — when true, logs event payloads
+skr_debug: false
+
+# Output directory for generated event JSON files
+skr_output_dir: "/tmp/splunk-kpis-reporter"
+
+# CI metadata (optional, for provenance tracking)
+skr_ci_metadata: {}
+
+# Availability threshold in microseconds (for oslat/cyclictest)
+skr_availability_threshold: 20

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/meta/main.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/meta/main.yml
@@ -1,0 +1,17 @@
+---
+galaxy_info:
+  author: Telco Verification CI/CD
+  description: >-
+    Builds Splunk HEC events matching the legacy fork-ran-integration schema
+    and POSTs them with retry support.
+  license: Apache-2.0
+  min_ansible_version: "2.14"
+  platforms:
+    - name: EL
+      versions:
+        - "9"
+  galaxy_tags:
+    - splunk
+    - reporting
+    - telcokpis
+dependencies: []

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/converge.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/converge.yml
@@ -1,0 +1,24 @@
+---
+# Molecule converge - runs splunk_kpis_reporter role in dry-run mode
+# No HTTP calls; events are written as JSON files to skr_output_dir
+- name: Converge
+  hosts: localhost
+  gather_facts: true
+
+  vars:
+    test_output_dir: /tmp/molecule-splunk-reporter
+
+  tasks:
+    - name: Execute splunk_kpis_reporter role (dry-run)
+      ansible.builtin.include_role:
+        name: splunk_kpis_reporter
+      vars:
+        skr_report_data: "{{ report_data }}"
+        skr_spoke_name: "spree-02"
+        skr_cluster_name: "spree-02"
+        skr_formal_test: true
+        skr_splunk_url: "https://splunk-hec.example.com:8088/services/collector"
+        skr_splunk_token: "test-token-not-real"
+        skr_do_send: false
+        skr_debug: true
+        skr_output_dir: "{{ test_output_dir }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/molecule.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/molecule.yml
@@ -1,0 +1,20 @@
+---
+# Molecule configuration for splunk_kpis_reporter role
+# Run via Makefile: make test (uses eco-ci-cd container)
+dependency:
+  name: galaxy
+  enabled: false
+driver:
+  name: delegated
+platforms:
+  - name: localhost
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      localhost:
+        ansible_connection: local
+  env:
+    ANSIBLE_ROLES_PATH: /eco-ci-cd/playbooks/telco-kpis/roles
+verifier:
+  name: ansible

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/prepare.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/prepare.yml
@@ -1,0 +1,141 @@
+---
+# Molecule prepare - creates mock report_data simulating report_generator output
+# Covers all 7 test types: oslat, cyclictest, ptp, reboot, cpu_util,
+# ztp_ai_deployment_time (maps to deployment), rfc2544 (maps to rfc-2544)
+- name: Prepare
+  hosts: localhost
+  gather_facts: true
+
+  vars:
+    test_output_dir: /tmp/molecule-splunk-reporter
+
+  tasks:
+    - name: Clean previous test artifacts
+      ansible.builtin.file:
+        path: "{{ test_output_dir }}"
+        state: absent
+
+    - name: Create test output directory
+      ansible.builtin.file:
+        path: "{{ test_output_dir }}"
+        state: directory
+        mode: '0755'
+
+    # yamllint disable rule:line-length
+    - name: Build mock report_data fact
+      ansible.builtin.set_fact:
+        report_data:
+          cluster_info:
+            sw_version: "4.22.0"
+            hub_version: "4.22.0"
+            kernel_version: "5.14.0-687.11.1.el9_8.x86_64+rt"
+            tuned_profile: "openshift-node-performance-profile"
+          hardware_info:
+            cpu_type: "Intel(R) Xeon(R) Gold 6330N CPU @ 2.20GHz"
+            cpu_model: "Intel(R) Xeon(R) Gold 6330N"
+            bios_version: "1.6.1"
+            microcode: "0xd0003b9"
+            architecture: "x86_64"
+          test_results:
+            # --- Oslat ---
+            oslat-spree-02-20260804-120000:
+              test_type: oslat
+              status: PASS
+              test_duration_seconds: 600
+              max_latency: 6
+              availability: "100.0"
+              cores: "3, 5"
+              core_results:
+                - {core: "3", max: 5, min: 0, avg: 1.0, availability: 100.0, number_of_nines: 100}
+                - {core: "5", max: 6, min: 0, avg: 1.0, availability: 100.0, number_of_nines: 100}
+            # --- Cyclictest ---
+            cyclictest-spree-02-20260804-130000:
+              test_type: cyclictest
+              status: PASS
+              test_duration: "10m"
+              max_overall: 14
+              threads: 2
+              availability_overall: 100.0
+              number_of_nines_overall: 100
+              thread_results:
+                - {thread: "0", min: 2, avg: 4, max: 14, availability: 100.0, number_of_nines: 100}
+                - {thread: "1", min: 2, avg: 3, max: 12, availability: 100.0, number_of_nines: 100}
+            # --- PTP ---
+            ptp-spree-02-20260804-140000:
+              test_type: ptp
+              status: PASS
+              ptp4l_max: 24
+              ptp4l_min: 1
+              ptp4l_avg: 3.448
+              phc2sys_max: 55
+              phc2sys_min: 2
+              phc2sys_avg: 5.204
+              ptp4l_restarts: 0
+            # --- Reboot (generates 2 events: soft_reboot + power_cycle) ---
+            reboot-spree-02-20260804-150000:
+              test_type: reboot
+              status: PASS
+              soft_reboot_iterations:
+                - {iteration: 1, total_minutes: 9.0, os_recovery: 2.1, openshift_reachable: 1.5, workload_recovery: 3.2, cluster_recovery: 2.2}
+                - {iteration: 2, total_minutes: 8.5, os_recovery: 2.0, openshift_reachable: 1.4, workload_recovery: 3.1, cluster_recovery: 2.0}
+              power_cycle_iterations:
+                - {iteration: 1, total_minutes: 8.28, os_recovery: 2.5, openshift_reachable: 1.8, workload_recovery: 2.5, cluster_recovery: 1.48}
+                - {iteration: 2, total_minutes: 6.37, os_recovery: 2.0, openshift_reachable: 1.2, workload_recovery: 2.0, cluster_recovery: 1.17}
+            # --- CPU Util ---
+            cpu_util-spree-02-20260804-160000:
+              test_type: cpu_util
+              status: PASS
+              duration: "8h 30m"
+              duration_breakdown:
+                total_human: "8h 30m"
+              scenarios:
+                - {name: "idle", max_cpu: 0.684, avg_cpu_total: 0.5}
+                - {name: "workloadlaunch", max_cpu: 0.801, avg_cpu_total: 0.6}
+                - {name: "mustgather", max_cpu: 0.788, avg_cpu_total: 0.55}
+                - {name: "promquery", max_cpu: 1.07, avg_cpu_total: 0.8}
+                - {name: "steadyworkload", max_cpu: 0.9, avg_cpu_total: 0.702}
+            # --- ZTP AI Deployment Time (maps to test_type: deployment) ---
+            ztp_ai_deployment_time-spree-02-20260804-170000:
+              test_type: ztp_ai_deployment_time
+              status: PASS
+              deployment_time_seconds: 4461
+              deployment_time_human: "1h 14m 21s"
+              reboot_count: 2
+              milestones:
+                - {event: "ZTP.ClusterInstanceCreated", timestamp: "2026-08-04T10:00:00Z"}
+                - {event: "AgentClusterInstall.Condition.Completed", timestamp: "2026-08-04T10:59:35Z"}
+                - {event: "TALM.CGU.Completed", timestamp: "2026-08-04T11:14:21Z"}
+            # --- RFC2544 (maps to test_type: rfc-2544) ---
+            rfc2544-spree-02-20260804-180000:
+              test_type: rfc2544
+              status: PASS
+              throughput_percent: 100.0
+              min_latency: 5.798
+              avg_latency: 6.909
+              max_latency: 26.51
+              actual_rate: 80.0
+              frame_size: 512.0
+              histogram_raw: "{x<1.28},0,0;{1.28<=x<2.56},0,0;{2.56<=x<3.84},0,0;{3.84<=x<5.12},12345,12340;{5.12<=x<6.40},16399016378,510635306;{6.40<=x<7.68},640535,223088;{7.68<=x<8.96},35804,5802;{8.96<=x<10.24},2065,425;{10.24<=x<11.52},228,228;{11.52<=x<12.80},228,228;{12.80<=x<14.08},228,228;{14.08<=x<15.36},228,228;{15.36<=x<16.64},228,228;{16.64<=x<17.92},228,228;{17.92<=x<32.92},413,33;{x>=32.92},228,228"
+              config:
+                lat_duration: "3600"
+                frame_size: "512"
+                lat_rate: "80"
+                port1: "1/1"
+                port2: "1/2"
+                testcfg: "rfc2544_config.tcc"
+                chassis: "spirent-chassis"
+                stcweb: "stcweb.example.com"
+                cluster: "spree-02"
+    # yamllint enable rule:line-length
+
+    - name: Display preparation summary
+      ansible.builtin.debug:
+        msg:
+          - "=========================================="
+          - "Test Environment Prepared"
+          - "=========================================="
+          - "Mock report_data created with {{ report_data.test_results | length }} test results"
+          - "Test types: {{ report_data.test_results | dict2items | map(attribute='value.test_type') | list | join(', ') }}"
+          - "Output directory: {{ test_output_dir }}"
+          - "Expected events: 8 (reboot generates 2)"
+          - "=========================================="

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/test.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/test.yml
@@ -1,0 +1,12 @@
+---
+# Complete test playbook - runs all phases in sequence
+# Usage: ansible-playbook -i localhost, -c local molecule/default/test.yml
+
+- name: Prepare test environment
+  import_playbook: prepare.yml
+
+- name: Converge - Run splunk_kpis_reporter role
+  import_playbook: converge.yml
+
+- name: Verify - Check event output
+  import_playbook: verify.yml

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/verify.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/molecule/default/verify.yml
@@ -1,0 +1,565 @@
+---
+# Molecule verify - validates generated Splunk HEC events match legacy schema
+# Covers: event count, common fields, test-specific fields, type safety
+- name: Verify
+  hosts: localhost
+  gather_facts: false
+
+  vars:
+    test_output_dir: /tmp/molecule-splunk-reporter
+
+  tasks:
+    # ================================================================
+    # Phase 1: Event discovery and parsing
+    # ================================================================
+
+    - name: Find all generated event files
+      ansible.builtin.find:
+        paths: "{{ test_output_dir }}"
+        patterns: "event-*.json"
+      register: event_files
+
+    - name: Verify correct number of events generated
+      ansible.builtin.assert:
+        that:
+          - event_files.files | length == 8
+        fail_msg: >-
+          Expected 8 event files (7 test types, reboot generates 2),
+          found {{ event_files.files | length }}.
+          Files: {{ event_files.files | map(attribute='path') | list }}
+        success_msg: "Correct: 8 event files generated"
+
+    - name: Read all event files
+      ansible.builtin.slurp:
+        src: "{{ item.path }}"
+      loop: "{{ event_files.files }}"
+      loop_control:
+        label: "{{ item.path | basename }}"
+      register: event_contents
+
+    # Build three structures in a single pass:
+    #   all_events     - flat list of all parsed events
+    #   events_by_type - dict keyed by test_type (reboot gets overwritten, handled separately)
+    #   reboot_events  - list of reboot events only
+    - name: Parse and classify all events
+      ansible.builtin.set_fact:
+        all_events: "{{ all_events | default([]) + [_evt] }}"
+        events_by_type: "{{ events_by_type | default({}) | combine({_evt.event.test_type: _evt}) }}"
+        reboot_events: "{{ reboot_events | default([]) + ([_evt] if _evt.event.test_type == 'reboot' else []) }}"
+      vars:
+        _evt: "{{ item.content | b64decode | from_json }}"
+      loop: "{{ event_contents.results }}"
+      loop_control:
+        label: "{{ (item.content | b64decode | from_json).event.test_type }}"
+
+    # ================================================================
+    # Phase 2: Verify expected test types are present
+    # ================================================================
+
+    - name: Verify all expected test types present
+      ansible.builtin.assert:
+        that:
+          - "'oslat' in events_by_type"
+          - "'cyclictest' in events_by_type"
+          - "'ptp' in events_by_type"
+          - "'reboot' in events_by_type"
+          - "'cpu_util' in events_by_type"
+          - "'deployment' in events_by_type"
+          - "'rfc-2544' in events_by_type"
+        fail_msg: "Missing test types. Found: {{ events_by_type.keys() | list }}"
+        success_msg: "All 7 expected test types present (including mapped deployment and rfc-2544)"
+
+    - name: Verify reboot generates exactly 2 events
+      ansible.builtin.assert:
+        that:
+          - reboot_events | length == 2
+        fail_msg: "Expected 2 reboot events, found {{ reboot_events | length }}"
+        success_msg: "Reboot generated exactly 2 events"
+
+    # ================================================================
+    # Phase 3: Common field validation for ALL events
+    # ================================================================
+
+    - name: Verify sourcetype is _json for all events
+      ansible.builtin.assert:
+        that:
+          - item.sourcetype == '_json'
+        fail_msg: >-
+          {{ item.event.test_type }}: sourcetype is '{{ item.sourcetype }}', expected '_json'
+        success_msg: "{{ item.event.test_type }}: sourcetype correct"
+      loop: "{{ all_events }}"
+      loop_control:
+        label: "{{ item.event.test_type }}"
+
+    - name: Verify data is directly in event (NOT in event.test)
+      ansible.builtin.assert:
+        that:
+          - item.event.test is not defined
+          - item.event.test_type is defined
+        fail_msg: >-
+          {{ item.event.test_type }}: Data wrapped in event.test -- must be directly in event.{fields}
+      loop: "{{ all_events }}"
+      loop_control:
+        label: "{{ item.event.test_type }}"
+
+    # yamllint disable rule:line-length
+    - name: Verify common fields present in all events
+      ansible.builtin.assert:
+        that:
+          - item.event.ocp_version == '4.22.0'
+          - item.event.ocp_build == '4.22.0'
+          - item.event.node_name == 'spree-02'
+          - item.event.formal | bool == true
+          - "'Xeon' in (item.event.cpu | string)"
+          - "'5.14.0' in (item.event.kernel | string)"
+          - item.event.status is defined
+          - item.event.cluster_artifacts is defined
+        fail_msg: "{{ item.event.test_type }}: Missing or incorrect common fields"
+        success_msg: "{{ item.event.test_type }}: Common fields valid"
+      loop: "{{ all_events }}"
+      loop_control:
+        label: "{{ item.event.test_type }}"
+
+    - name: Verify cluster_artifacts has ocp.ocp_version_spoke
+      ansible.builtin.assert:
+        that:
+          - item.event.cluster_artifacts.ocp is defined
+          - item.event.cluster_artifacts.ocp.ocp_version_spoke == '4.22.0'
+          - item.event.cluster_artifacts.openshift_version == '4.22.0'
+          - item.event.cluster_artifacts.cluster_name == 'spree-02'
+        fail_msg: >-
+          {{ item.event.test_type }}: cluster_artifacts structure incorrect.
+          Got: {{ item.event.cluster_artifacts | to_json }}
+        success_msg: "{{ item.event.test_type }}: cluster_artifacts correct"
+      loop: "{{ all_events }}"
+      loop_control:
+        label: "{{ item.event.test_type }}"
+
+    # ================================================================
+    # Phase 4: Oslat-specific assertions
+    # ================================================================
+
+    - name: "OSLAT: Verify test_units array with legacy fields"
+      vars:
+        oslat: "{{ events_by_type.oslat.event }}"
+      ansible.builtin.assert:
+        that:
+          - oslat.test_type == 'oslat'
+          - oslat.test_units is defined
+          - oslat.test_units | length == 2
+          - oslat.test_units[0].index is defined
+          - oslat.test_units[0].max_latency is defined
+          - oslat.test_units[0].min_latency is defined
+          - oslat.test_units[0].avg_latency is defined
+          - oslat.test_units[0].availability is defined
+          - oslat.test_units[0].number_of_nines is defined
+          - oslat.duration is defined
+        fail_msg: "Oslat event missing test_units with 6 legacy fields (index, max_latency, min_latency, avg_latency, availability, number_of_nines)"
+        success_msg: "Oslat: test_units with 6 legacy fields per core -- correct"
+
+    - name: "OSLAT: Verify test_units values for core 3"
+      vars:
+        unit: "{{ events_by_type.oslat.event.test_units[0] }}"
+      ansible.builtin.assert:
+        that:
+          - unit.index == '3'
+          - unit.max_latency == 5
+          - unit.min_latency == 0
+          - unit.avg_latency == 1.0
+          - unit.availability == 100.0
+          - unit.number_of_nines == 100
+        fail_msg: "Oslat test_units[0] values incorrect: {{ unit }}"
+        success_msg: "Oslat: core 3 values correct"
+
+    - name: "OSLAT: Verify test_units values for core 5"
+      vars:
+        unit: "{{ events_by_type.oslat.event.test_units[1] }}"
+      ansible.builtin.assert:
+        that:
+          - unit.index == '5'
+          - unit.max_latency == 6
+          - unit.min_latency == 0
+          - unit.avg_latency == 1.0
+        fail_msg: "Oslat test_units[1] values incorrect: {{ unit }}"
+        success_msg: "Oslat: core 5 values correct"
+
+    - name: "OSLAT: Verify duration field"
+      ansible.builtin.assert:
+        that:
+          - events_by_type.oslat.event.duration | string == '600'
+        fail_msg: "Oslat duration should be 600, got {{ events_by_type.oslat.event.duration }}"
+        success_msg: "Oslat: duration correct"
+
+    # ================================================================
+    # Phase 5: Cyclictest-specific assertions
+    # ================================================================
+
+    - name: "CYCLICTEST: Verify test_units array with legacy fields"
+      vars:
+        cyclic: "{{ events_by_type.cyclictest.event }}"
+      ansible.builtin.assert:
+        that:
+          - cyclic.test_type == 'cyclictest'
+          - cyclic.test_units is defined
+          - cyclic.test_units | length == 2
+          - cyclic.test_units[0].index is defined
+          - cyclic.test_units[0].max_latency is defined
+          - cyclic.test_units[0].min_latency is defined
+          - cyclic.test_units[0].avg_latency is defined
+          - cyclic.test_units[0].availability is defined
+          - cyclic.test_units[0].number_of_nines is defined
+        fail_msg: "Cyclictest event missing test_units with 6 legacy fields"
+        success_msg: "Cyclictest: test_units with 6 legacy fields per thread -- correct"
+
+    - name: "CYCLICTEST: Verify test_units values for thread 0"
+      vars:
+        unit: "{{ events_by_type.cyclictest.event.test_units[0] }}"
+      ansible.builtin.assert:
+        that:
+          - unit.index == '0'
+          - unit.max_latency == 14
+          - unit.min_latency == 2
+          - unit.avg_latency == 4
+        fail_msg: "Cyclictest test_units[0] values incorrect: {{ unit }}"
+        success_msg: "Cyclictest: thread 0 values correct"
+
+    - name: "CYCLICTEST: Verify overall availability and number_of_nines"
+      vars:
+        cyclic: "{{ events_by_type.cyclictest.event }}"
+      ansible.builtin.assert:
+        that:
+          - cyclic.availability_overall is defined
+          - cyclic.number_of_nines_overall is defined
+        fail_msg: "Cyclictest missing overall availability/number_of_nines at event level"
+        success_msg: "Cyclictest: overall availability and number_of_nines present"
+
+    # ================================================================
+    # Phase 6: PTP-specific assertions
+    # ================================================================
+
+    - name: "PTP: Verify flat metric fields"
+      vars:
+        ptp: "{{ events_by_type.ptp.event }}"
+      ansible.builtin.assert:
+        that:
+          - ptp.test_type == 'ptp'
+          - ptp.ptp4l_max_offset is defined
+          - ptp.ptp4l_min_offset is defined
+          - ptp.ptp4l_avg_offset is defined
+          - ptp.phc2sys_max_offset is defined
+          - ptp.phc2sys_min_offset is defined
+          - ptp.phc2sys_avg_offset is defined
+          - ptp.ptp4l_restarts is defined
+        fail_msg: "PTP event missing required metric fields"
+        success_msg: "PTP: all metric fields present"
+
+    - name: "PTP: Verify metric values"
+      vars:
+        ptp: "{{ events_by_type.ptp.event }}"
+      ansible.builtin.assert:
+        that:
+          - ptp.ptp4l_max_offset | float == 24.0
+          - ptp.ptp4l_avg_offset | float == 3.448
+          - ptp.phc2sys_max_offset | float == 55.0
+          - ptp.phc2sys_avg_offset | float == 5.204
+          - ptp.ptp4l_restarts | int == 0
+        fail_msg: "PTP metric values incorrect"
+        success_msg: "PTP: metric values correct"
+
+    # ================================================================
+    # Phase 7: Reboot-specific assertions (2 events)
+    # ================================================================
+
+    - name: "REBOOT: Identify soft_reboot event"
+      ansible.builtin.set_fact:
+        soft_reboot_evt: "{{ item }}"
+      when: item.event.reboot_type == 'soft_reboot'
+      loop: "{{ reboot_events }}"
+      loop_control:
+        label: "{{ item.event.reboot_type }}"
+
+    - name: "REBOOT: Identify power_cycle event"
+      ansible.builtin.set_fact:
+        power_cycle_evt: "{{ item }}"
+      when: item.event.reboot_type == 'power_cycle'
+      loop: "{{ reboot_events }}"
+      loop_control:
+        label: "{{ item.event.reboot_type }}"
+
+    - name: "REBOOT: Verify both reboot_type values present"
+      ansible.builtin.assert:
+        that:
+          - soft_reboot_evt is defined
+          - power_cycle_evt is defined
+          - soft_reboot_evt.event.reboot_type == 'soft_reboot'
+          - power_cycle_evt.event.reboot_type == 'power_cycle'
+        fail_msg: "Expected reboot events with reboot_type soft_reboot and power_cycle"
+        success_msg: "Reboot: both reboot_type values (soft_reboot, power_cycle) present"
+
+    - name: "REBOOT: Verify soft_reboot has Iterations array"
+      ansible.builtin.assert:
+        that:
+          - soft_reboot_evt.event.Iterations is defined
+          - soft_reboot_evt.event.Iterations | length == 2
+          - soft_reboot_evt.event.Iterations[0].total_minutes is defined
+        fail_msg: "Soft reboot event missing Iterations array or total_minutes field"
+        success_msg: "Reboot soft_reboot: Iterations array with total_minutes present"
+
+    - name: "REBOOT: Verify soft_reboot total_minutes is numeric (not string)"
+      ansible.builtin.assert:
+        that:
+          - soft_reboot_evt.event.Iterations[0].total_minutes | type_debug in ['float', 'int']
+          - soft_reboot_evt.event.Iterations[0].total_minutes == 9.0
+        fail_msg: >-
+          Soft reboot Iterations[0].total_minutes must be numeric 9.0, got
+          {{ soft_reboot_evt.event.Iterations[0].total_minutes }}
+          (type: {{ soft_reboot_evt.event.Iterations[0].total_minutes | type_debug }})
+        success_msg: "Reboot soft_reboot: total_minutes is numeric"
+
+    - name: "REBOOT: Verify power_cycle has Iterations array"
+      ansible.builtin.assert:
+        that:
+          - power_cycle_evt.event.Iterations is defined
+          - power_cycle_evt.event.Iterations | length == 2
+          - power_cycle_evt.event.Iterations[0].total_minutes is defined
+        fail_msg: "Power cycle event missing Iterations array"
+        success_msg: "Reboot power_cycle: Iterations array with total_minutes present"
+
+    - name: "REBOOT: Verify power_cycle total_minutes is numeric (not string)"
+      ansible.builtin.assert:
+        that:
+          - power_cycle_evt.event.Iterations[0].total_minutes | type_debug in ['float', 'int']
+          - power_cycle_evt.event.Iterations[0].total_minutes == 8.28
+        fail_msg: >-
+          Power cycle Iterations[0].total_minutes must be numeric 8.28, got
+          {{ power_cycle_evt.event.Iterations[0].total_minutes }}
+          (type: {{ power_cycle_evt.event.Iterations[0].total_minutes | type_debug }})
+        success_msg: "Reboot power_cycle: total_minutes is numeric"
+
+    # ================================================================
+    # Phase 8: CPU Util-specific assertions
+    # ================================================================
+
+    - name: "CPU_UTIL: Verify scenarios array with duration"
+      vars:
+        cpu: "{{ events_by_type.cpu_util.event }}"
+      ansible.builtin.assert:
+        that:
+          - cpu.test_type == 'cpu_util'
+          - cpu.scenarios is defined
+          - cpu.scenarios | length == 5
+          - cpu.scenarios[0].name is defined
+          - cpu.scenarios[0].duration is defined
+          - cpu.scenarios[0].duration == '8h 30m'
+        fail_msg: "CPU util event missing scenarios array or duration field. Got: {{ cpu.scenarios | default('undefined') }}"
+        success_msg: "CPU util: scenarios array with duration field correct"
+
+    - name: "CPU_UTIL: Verify all scenarios have duration field"
+      ansible.builtin.assert:
+        that:
+          - item.duration is defined
+          - item.duration | length > 0
+        fail_msg: "CPU util scenario '{{ item.name }}' missing duration field"
+      loop: "{{ events_by_type.cpu_util.event.scenarios }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    # ================================================================
+    # Phase 9: Deployment (ZTP) specific assertions
+    # ================================================================
+
+    - name: "DEPLOYMENT: Verify required fields present"
+      vars:
+        deploy: "{{ events_by_type.deployment.event }}"
+      ansible.builtin.assert:
+        that:
+          - deploy.test_type == 'deployment'
+          - deploy.total_minutes is defined
+          - deploy.reboot_count is defined
+          - deploy.iteration is defined
+          - deploy.stages is defined
+          - deploy.stages | length == 2
+          - deploy.stages[0].stage_name is defined
+          - deploy.stages[0].time is defined
+          - deploy.stages[1].stage_name is defined
+          - deploy.stages[1].time is defined
+        fail_msg: "Deployment event missing required fields: {{ deploy | to_json }}"
+        success_msg: "Deployment: all required fields present"
+
+    - name: "DEPLOYMENT: Verify total_minutes is float (not string)"
+      ansible.builtin.assert:
+        that:
+          - events_by_type.deployment.event.total_minutes | type_debug in ['float', 'int']
+          - events_by_type.deployment.event.total_minutes | float == 74.35
+        fail_msg: >-
+          Deployment total_minutes must be numeric 74.35, got
+          {{ events_by_type.deployment.event.total_minutes }}
+          (type: {{ events_by_type.deployment.event.total_minutes | type_debug }})
+        success_msg: "Deployment: total_minutes is numeric 74.35"
+
+    - name: "DEPLOYMENT: Verify reboot_count is integer (not string)"
+      ansible.builtin.assert:
+        that:
+          - events_by_type.deployment.event.reboot_count | type_debug == 'int'
+          - events_by_type.deployment.event.reboot_count == 2
+        fail_msg: >-
+          Deployment reboot_count must be integer 2, got
+          {{ events_by_type.deployment.event.reboot_count }}
+          (type: {{ events_by_type.deployment.event.reboot_count | type_debug }})
+        success_msg: "Deployment: reboot_count is integer 2"
+
+    - name: "DEPLOYMENT: Verify iteration is integer (not string)"
+      ansible.builtin.assert:
+        that:
+          - events_by_type.deployment.event.iteration | type_debug == 'int'
+          - events_by_type.deployment.event.iteration == 1
+        fail_msg: >-
+          Deployment iteration must be integer 1, got
+          {{ events_by_type.deployment.event.iteration }}
+          (type: {{ events_by_type.deployment.event.iteration | type_debug }})
+        success_msg: "Deployment: iteration is integer 1"
+
+    - name: "DEPLOYMENT: Verify stages[].time are integers"
+      ansible.builtin.assert:
+        that:
+          - item.time | type_debug == 'int'
+          - item.time | int > 0
+        fail_msg: >-
+          Deployment stage '{{ item.stage_name }}' time must be integer, got
+          {{ item.time }} (type: {{ item.time | type_debug }})
+        success_msg: "Deployment stage {{ item.stage_name }}: time is integer {{ item.time }}"
+      loop: "{{ events_by_type.deployment.event.stages }}"
+      loop_control:
+        label: "{{ item.stage_name }}"
+
+    - name: "DEPLOYMENT: Verify stage names and computed times"
+      vars:
+        stages: "{{ events_by_type.deployment.event.stages }}"
+      ansible.builtin.assert:
+        that:
+          # stage 1: ClusterInstance -> Install = 10:59:35 - 10:00:00 = 3575s
+          - stages[0].stage_name == 'deploy_sno_du_node'
+          - stages[0].time == 3575
+          # stage 2: Install -> CGU = 11:14:21 - 10:59:35 = 886s
+          - stages[1].stage_name == 'wait_for_du_profile'
+          - stages[1].time == 886
+        fail_msg: "Deployment stage times incorrect. Expected deploy_sno_du_node=3575, wait_for_du_profile=886. Got: {{ stages }}"
+        success_msg: "Deployment: stage times computed correctly from milestones"
+
+    # ================================================================
+    # Phase 10: RFC2544-specific assertions
+    # ================================================================
+
+    - name: "RFC2544: Verify required fields present"
+      vars:
+        rfc: "{{ events_by_type['rfc-2544'].event }}"
+      ansible.builtin.assert:
+        that:
+          - rfc.test_type == 'rfc-2544'
+          - rfc.max_throughput is defined
+          - rfc.max_delay is defined
+          - rfc.avg_delay is defined
+          - rfc.min_delay is defined
+          - rfc.frame_size is defined
+          - rfc.test_throughput is defined
+          - rfc.duration is defined
+          - rfc.histogram is defined
+          - rfc.under_30_nines is defined
+        fail_msg: "RFC2544 event missing required fields"
+        success_msg: "RFC2544: all required fields present"
+
+    - name: "RFC2544: Verify numeric fields are floats (not strings)"
+      ansible.builtin.assert:
+        that:
+          - events_by_type['rfc-2544'].event.max_throughput | type_debug in ['float', 'int']
+          - events_by_type['rfc-2544'].event.max_delay | type_debug in ['float', 'int']
+          - events_by_type['rfc-2544'].event.avg_delay | type_debug in ['float', 'int']
+          - events_by_type['rfc-2544'].event.min_delay | type_debug in ['float', 'int']
+          - events_by_type['rfc-2544'].event.frame_size | type_debug in ['float', 'int']
+          - events_by_type['rfc-2544'].event.test_throughput | type_debug in ['float', 'int']
+        fail_msg: >-
+          RFC2544 numeric fields must be floats, not strings.
+          Types: max_throughput={{ events_by_type['rfc-2544'].event.max_throughput | type_debug }},
+          max_delay={{ events_by_type['rfc-2544'].event.max_delay | type_debug }},
+          avg_delay={{ events_by_type['rfc-2544'].event.avg_delay | type_debug }},
+          min_delay={{ events_by_type['rfc-2544'].event.min_delay | type_debug }},
+          frame_size={{ events_by_type['rfc-2544'].event.frame_size | type_debug }},
+          test_throughput={{ events_by_type['rfc-2544'].event.test_throughput | type_debug }}
+        success_msg: "RFC2544: all numeric fields are proper numeric types"
+
+    - name: "RFC2544: Verify numeric values"
+      vars:
+        rfc: "{{ events_by_type['rfc-2544'].event }}"
+      ansible.builtin.assert:
+        that:
+          - rfc.max_throughput | float == 100.0
+          - rfc.max_delay | float == 26.51
+          - rfc.avg_delay | float == 6.909
+          - rfc.min_delay | float == 5.798
+          - rfc.frame_size | float == 512.0
+          - rfc.test_throughput | float == 80.0
+        fail_msg: "RFC2544 numeric values incorrect"
+        success_msg: "RFC2544: numeric values correct"
+
+    - name: "RFC2544: Verify histogram is non-empty array"
+      ansible.builtin.assert:
+        that:
+          - events_by_type['rfc-2544'].event.histogram | length > 0
+        fail_msg: "RFC2544 histogram should be non-empty array"
+        success_msg: "RFC2544: histogram is non-empty ({{ events_by_type['rfc-2544'].event.histogram | length }} entries)"
+
+    - name: "RFC2544: Verify under_30_nines is array of 2 elements"
+      ansible.builtin.assert:
+        that:
+          - events_by_type['rfc-2544'].event.under_30_nines | length == 2
+        fail_msg: "RFC2544 under_30_nines should be array of 2 elements, got {{ events_by_type['rfc-2544'].event.under_30_nines }}"
+        success_msg: "RFC2544: under_30_nines array correct"
+
+    - name: "RFC2544: Verify duration field present"
+      ansible.builtin.assert:
+        that:
+          - events_by_type['rfc-2544'].event.duration | string | length > 0
+        fail_msg: "RFC2544 duration field missing or empty"
+        success_msg: "RFC2544: duration field present"
+    # yamllint enable rule:line-length
+
+    # ================================================================
+    # Phase 11: Cleanup and summary
+    # ================================================================
+
+    - name: Clean up test artifacts
+      ansible.builtin.file:
+        path: "{{ test_output_dir }}"
+        state: absent
+
+    - name: Display verification summary
+      ansible.builtin.debug:
+        msg:
+          - "=========================================="
+          - "All verification checks passed!"
+          - "=========================================="
+          - "Events validated: {{ all_events | length }}"
+          - ""
+          - "Schema compliance:"
+          - "  - sourcetype: _json (all events)"
+          - "  - Data directly in event.{fields} (no event.test wrapper)"
+          - "  - Common fields: ocp_version, ocp_build, node_name, formal, cpu, kernel, status"
+          - "  - cluster_artifacts.ocp.ocp_version_spoke: present (all events)"
+          - ""
+          - "Test-type validations:"
+          - "  - oslat: test_units[2] with 6 legacy fields per core, duration"
+          - "  - cyclictest: test_units[2] with 6 legacy fields per thread, availability_overall"
+          - "  - ptp: offset metric fields with correct values"
+          - "  - reboot: 2 events (soft_reboot + power_cycle), Iterations with numeric total_minutes"
+          - "  - cpu_util: scenarios[5] with duration field"
+          - "  - deployment: total_minutes(float), reboot_count(int), iteration(int), stages[].time(int)"
+          - "  - rfc-2544: max_throughput, delays, frame_size (all floats), histogram, under_30_nines"
+          - ""
+          - "Type safety verified:"
+          - "  - Deployment total_minutes: numeric (not string)"
+          - "  - Deployment reboot_count: integer (not string)"
+          - "  - Deployment iteration: integer (not string)"
+          - "  - Deployment stages[].time: integers (not strings)"
+          - "  - RFC2544 throughput/latency: floats (not strings)"
+          - "  - Reboot Iterations[].total_minutes: numeric (not string)"
+          - "=========================================="

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/build_and_send.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/build_and_send.yml
@@ -1,0 +1,34 @@
+---
+# Build Splunk HEC event(s) for one test result and optionally send them
+# Event maps can set _skr_multi_events (list) for multiple events per test result
+
+- name: Set test type
+  ansible.builtin.set_fact:
+    _skr_test_type: "{{ _skr_test_item.value.test_type }}"
+
+- name: Initialize test-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific: {}
+    _skr_multi_events: []
+
+- name: Check if event map exists for {{ _skr_test_type }}
+  ansible.builtin.stat:
+    path: "{{ role_path }}/tasks/event_maps/{{ _skr_test_type }}.yml"
+  register: _skr_event_map_stat
+  delegate_to: localhost
+
+- name: Load test-type-specific field mapping
+  when: _skr_event_map_stat.stat.exists
+  ansible.builtin.include_tasks: "event_maps/{{ _skr_test_type }}.yml"
+
+- name: Normalize to events list
+  ansible.builtin.set_fact:
+    _skr_events_to_send: "{{ _skr_multi_events if (_skr_multi_events | length > 0) else [_skr_test_specific] }}"
+
+- name: Process each event
+  ansible.builtin.include_tasks: send_single_event.yml
+  loop: "{{ _skr_events_to_send }}"
+  loop_control:
+    loop_var: _skr_event_fields
+    index_var: _skr_event_idx
+    label: "{{ _skr_event_fields.test_type | default(_skr_test_type) }}-{{ _skr_event_idx }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/bios_validation.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/bios_validation.yml
@@ -1,0 +1,9 @@
+---
+# Map bios_validation report_data fields to legacy Splunk event schema
+
+- name: Set bios_validation-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific:
+      passed: "{{ _skr_test_item.value.passed | default(0) }}"
+      failed: "{{ _skr_test_item.value.failed | default(0) }}"
+      skipped: "{{ _skr_test_item.value.skipped | default(0) }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/cpu_util.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/cpu_util.yml
@@ -1,0 +1,12 @@
+---
+# Map cpu_util report_data fields to legacy Splunk event schema
+
+- name: Set cpu_util-specific fields
+  vars:
+    _skr_cpu_duration: "{{ _skr_test_item.value.duration_breakdown.total_human | default(_skr_test_item.value.duration | default('')) }}"
+  ansible.builtin.set_fact:
+    _skr_test_specific:
+      scenarios: >-
+        {{ _skr_test_item.value.scenarios | default([])
+           | map('combine', {'duration': _skr_cpu_duration})
+           | list | to_json | from_json }}

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/cyclictest.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/cyclictest.yml
@@ -1,0 +1,27 @@
+---
+# Map cyclictest report_data fields to legacy Splunk event schema
+
+- name: Build cyclictest test_units from thread_results
+  ansible.builtin.set_fact:
+    _skr_cyclictest_units: >-
+      {{ _skr_cyclictest_units | default([]) + [{
+        'index': item.thread | string,
+        'max_latency': item.max | default(0),
+        'min_latency': item.min | default(0),
+        'avg_latency': item.avg | default(0),
+        'availability': item.availability | default(100.0),
+        'number_of_nines': item.number_of_nines | default(100)
+      }] }}
+  loop: "{{ _skr_test_item.value.thread_results | default([]) }}"
+  loop_control:
+    label: "thread {{ item.thread | default('?') }}"
+
+- name: Set cyclictest-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific:
+      duration: "{{ _skr_test_item.value.test_duration | default('') }}"
+      test_units: "{{ _skr_cyclictest_units | default([]) }}"
+      max_overall: "{{ _skr_test_item.value.max_overall | default(0) }}"
+      availability_overall: "{{ _skr_test_item.value.availability_overall | default(100.0) }}"
+      number_of_nines_overall: "{{ _skr_test_item.value.number_of_nines_overall | default(100) }}"
+      threads: "{{ _skr_test_item.value.threads | default(0) }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/oslat.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/oslat.yml
@@ -1,0 +1,26 @@
+---
+# Map oslat report_data fields to legacy Splunk event schema
+
+- name: Build oslat test_units from core_results
+  ansible.builtin.set_fact:
+    _skr_oslat_units: >-
+      {{ _skr_oslat_units | default([]) + [{
+        'index': item.core | string,
+        'max_latency': item.max | default(0),
+        'min_latency': item.min | default(0),
+        'avg_latency': item.avg | default(0),
+        'availability': item.availability | default(100.0),
+        'number_of_nines': item.number_of_nines | default(100)
+      }] }}
+  loop: "{{ _skr_test_item.value.core_results | default([]) }}"
+  loop_control:
+    label: "core {{ item.core | default('?') }}"
+
+- name: Set oslat-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific:
+      duration: "{{ _skr_test_item.value.test_duration_seconds | default('') }}"
+      test_units: "{{ _skr_oslat_units | default([]) }}"
+      max_latency: "{{ _skr_test_item.value.max_latency | default(0) }}"
+      availability: "{{ _skr_test_item.value.availability | default('100.0') }}"
+      cores: "{{ _skr_test_item.value.cores | default('') }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/ptp.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/ptp.yml
@@ -1,0 +1,14 @@
+---
+# Map PTP report_data fields to legacy Splunk event schema
+
+- name: Set ptp-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific:
+      ptp4l_max_offset: "{{ _skr_test_item.value.ptp4l_max | default(0) | regex_replace('^N/A$', '0') | float }}"
+      ptp4l_min_offset: "{{ _skr_test_item.value.ptp4l_min | default(0) | regex_replace('^N/A$', '0') | float }}"
+      ptp4l_avg_offset: "{{ _skr_test_item.value.ptp4l_avg | default(0) | regex_replace('^N/A$', '0') | float }}"
+      phc2sys_max_offset: "{{ _skr_test_item.value.phc2sys_max | default(0) | regex_replace('^N/A$', '0') | float }}"
+      phc2sys_min_offset: "{{ _skr_test_item.value.phc2sys_min | default(0) | regex_replace('^N/A$', '0') | float }}"
+      phc2sys_avg_offset: "{{ _skr_test_item.value.phc2sys_avg | default(0) | regex_replace('^N/A$', '0') | float }}"
+      duration: "{{ _skr_test_item.value.duration | default('') }}"
+      ptp4l_restarts: "{{ _skr_test_item.value.ptp4l_restarts | default(0) | regex_replace('^N/A$', '0') | int }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/rds_compare.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/rds_compare.yml
@@ -1,0 +1,9 @@
+---
+# Map rds_compare report_data fields to legacy Splunk event schema
+
+- name: Set rds_compare-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific:
+      crs_with_diffs: "{{ _skr_test_item.value.crs_with_diffs | default(0) }}"
+      total_crs: "{{ _skr_test_item.value.total_crs | default(0) }}"
+      missing_crs: "{{ _skr_test_item.value.missing_crs | default(0) }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/reboot.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/reboot.yml
@@ -1,0 +1,14 @@
+---
+# Map reboot report_data fields to legacy Splunk event schema
+# Legacy sends TWO events per test: one for soft_reboot, one for power_cycle
+# Each contains an Iterations array with per-iteration stage timings
+
+- name: Set reboot multi-events (soft_reboot + power_cycle)
+  ansible.builtin.set_fact:
+    _skr_multi_events:
+      - test_type: "reboot"
+        reboot_type: "soft_reboot"
+        Iterations: "{{ _skr_test_item.value.soft_reboot_iterations | default([]) | to_json | from_json }}"
+      - test_type: "reboot"
+        reboot_type: "power_cycle"
+        Iterations: "{{ _skr_test_item.value.power_cycle_iterations | default([]) | to_json | from_json }}"

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/rfc2544.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/rfc2544.yml
@@ -1,0 +1,118 @@
+---
+# Map rfc2544 report_data fields to legacy Splunk event schema
+# Transforms raw histogram string into structured arrays for dashboard charts
+
+- name: Transform histogram data for Splunk (legacy format)
+  ansible.builtin.shell: |
+    python3 << 'PYEOF'
+    import os, re, json
+
+    hist_str = os.environ.get('HIST_RAW', '')
+    max_delay = float(os.environ.get('MAX_DELAY', '0'))
+
+    if not hist_str.strip():
+        print(json.dumps({'histogram': [], 'under_30_nines': [100, 100]}))
+        raise SystemExit(0)
+
+    entries = [e.strip() for e in hist_str.split(';') if e.strip()]
+    histogram = []
+    total_fwd = 0
+    total_bwd = 0
+    under30_fwd = 0
+    under30_bwd = 0
+
+    for entry in entries:
+        bin_match = re.search(r'\{([^{}]*)\}', entry)
+        if not bin_match:
+            continue
+        bin_desc = bin_match.group(1)
+        parts = entry.split(',')
+        fwd_str = parts[1].strip() if len(parts) > 1 else '0'
+        bwd_str = parts[2].strip() if len(parts) > 2 else '0'
+        fwd = int(fwd_str)
+        bwd = int(bwd_str)
+        total_fwd += fwd
+        total_bwd += bwd
+
+        nums = [float(v) for v in re.findall(r'\d+\.\d+', bin_desc)]
+        if '>=' in bin_desc:
+            mid = str(nums[0]) + '+' if nums else '0+'
+            is_under_30 = False
+        else:
+            if len(nums) >= 2:
+                mid = round(sum(nums) / len(nums), 2)
+            elif len(nums) == 1:
+                mid = nums[0]
+            else:
+                mid = 0
+            is_under_30 = (nums[-1] if nums else 0) < 30.0
+
+        if is_under_30:
+            under30_fwd += fwd
+            under30_bwd += bwd
+
+        histogram.append({
+            'bin': mid,
+            'values': [
+                {'val': fwd_str, 'direction': 'forward'},
+                {'val': bwd_str, 'direction': 'back'}
+            ]
+        })
+
+    def calc_nines(total, under):
+        if total == 0:
+            return 100
+        pct = (under / total) * 100
+        if pct == 100:
+            return 100
+        pct_str = f'{pct:.10f}'
+        decimal = pct_str.split('.')[1] if '.' in pct_str else ''
+        count = 0
+        for c in decimal:
+            if c == '9':
+                count += 1
+            else:
+                break
+        return count
+
+    if max_delay < 30.0:
+        under_30_nines = [100, 100]
+    else:
+        under_30_nines = [
+            calc_nines(total_fwd, under30_fwd),
+            calc_nines(total_bwd, under30_bwd)
+        ]
+
+    print(json.dumps({'histogram': histogram, 'under_30_nines': under_30_nines}))
+    PYEOF
+  environment:
+    HIST_RAW: "{{ _skr_test_item.value.histogram_raw | default('') }}"
+    MAX_DELAY: "{{ _skr_test_item.value.max_latency | default(0) | string }}"
+  register: _skr_hist_result
+  changed_when: false
+  failed_when: false
+
+- name: Parse histogram transformation result
+  ansible.builtin.set_fact:
+    _skr_hist_data: >-
+      {{ _skr_hist_result.stdout | from_json
+         if (_skr_hist_result.rc | default(1) == 0
+             and _skr_hist_result.stdout | default('') | length > 0)
+         else {'histogram': [], 'under_30_nines': [100, 100]} }}
+
+- name: Set rfc2544-specific fields
+  ansible.builtin.set_fact:
+    _skr_test_specific: >-
+      {{ {
+        'test_type': 'rfc-2544',
+        'max_throughput': _skr_test_item.value.throughput_percent | default(0) | float,
+        'max_delay': _skr_test_item.value.max_latency | default(0) | float,
+        'avg_delay': _skr_test_item.value.avg_latency | default(0) | float,
+        'min_delay': _skr_test_item.value.min_latency | default(0) | float,
+        'frame_size': _skr_test_item.value.frame_size | default(0) | float,
+        'duration': _skr_test_item.value.config.lat_duration | default('') | string,
+        'test_throughput': _skr_test_item.value.actual_rate | default(0) | float,
+        'nic': _skr_test_item.value.config.port1 | default(''),
+        'histogram': _skr_hist_data.histogram | default([]),
+        'under_30_nines': _skr_hist_data.under_30_nines | default([100, 100])
+      } }}

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/ztp_ai_deployment_time.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/event_maps/ztp_ai_deployment_time.yml
@@ -1,0 +1,51 @@
+---
+# Map ztp_ai_deployment_time report_data fields to legacy Splunk event schema
+# Legacy sends two stages: deploy_sno_du_node (start→install) and wait_for_du_profile (install→CGU)
+
+- name: Find milestone timestamps for stage split
+  ansible.builtin.set_fact:
+    _skr_deploy_start_ts: >-
+      {{ (_skr_test_item.value.milestones | default([])
+          | selectattr('event', 'equalto', 'ZTP.ClusterInstanceCreated')
+          | map(attribute='timestamp') | first | default('')) }}
+    _skr_deploy_install_ts: >-
+      {{ (_skr_test_item.value.milestones | default([])
+          | selectattr('event', 'equalto', 'AgentClusterInstall.Condition.Completed')
+          | map(attribute='timestamp') | first | default('')) }}
+    _skr_deploy_end_ts: >-
+      {{ (_skr_test_item.value.milestones | default([])
+          | selectattr('event', 'equalto', 'TALM.CGU.Completed')
+          | map(attribute='timestamp') | first | default('')) }}
+
+- name: Compute stage times from milestone timestamps
+  when:
+    - _skr_deploy_start_ts | trim | length > 0
+    - _skr_deploy_install_ts | trim | length > 0
+    - _skr_deploy_end_ts | trim | length > 0
+  ansible.builtin.set_fact:
+    _skr_deploy_sno_seconds: >-
+      {{ ((_skr_deploy_install_ts | trim | to_datetime('%Y-%m-%dT%H:%M:%SZ'))
+        - (_skr_deploy_start_ts | trim | to_datetime('%Y-%m-%dT%H:%M:%SZ'))).total_seconds() | int }}
+    _skr_wait_du_seconds: >-
+      {{ ((_skr_deploy_end_ts | trim | to_datetime('%Y-%m-%dT%H:%M:%SZ'))
+        - (_skr_deploy_install_ts | trim | to_datetime('%Y-%m-%dT%H:%M:%SZ'))).total_seconds() | int }}
+
+- name: Fall back to total time when milestones unavailable
+  when: _skr_deploy_sno_seconds is not defined
+  ansible.builtin.set_fact:
+    _skr_deploy_sno_seconds: "{{ _skr_test_item.value.deployment_time_seconds | default(0) | float | round | int }}"
+    _skr_wait_du_seconds: null
+
+- name: Set deployment-specific fields (legacy schema)
+  ansible.builtin.set_fact:
+    _skr_test_specific: >-
+      {{ {
+        'test_type': 'deployment',
+        'iteration': 1,
+        'total_minutes': ((_skr_test_item.value.deployment_time_seconds | default(0) | float) / 60) | round(2),
+        'reboot_count': (_skr_test_item.value.reboot_count | default(0) | string | regex_replace('^N/A$', '0')) | int,
+        'stages': [
+          {'stage_name': 'deploy_sno_du_node', 'time': _skr_deploy_sno_seconds | default(0) | int},
+          {'stage_name': 'wait_for_du_profile', 'time': (_skr_wait_du_seconds | default(0)) | int}
+        ]
+      } }}

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/main.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/main.yml
@@ -1,0 +1,93 @@
+---
+# Main entry point for splunk_kpis_reporter role
+# Builds Splunk HEC events matching legacy fork-ran-integration schema
+
+- name: Validate required parameters
+  ansible.builtin.assert:
+    that:
+      - skr_report_data | length > 0
+      - skr_report_data.test_results is defined
+      - skr_spoke_name | length > 0
+    fail_msg: "Missing required parameters: skr_report_data (with test_results) and skr_spoke_name"
+
+- name: Validate Splunk credentials when sending is enabled
+  when: skr_do_send | bool
+  ansible.builtin.assert:
+    that:
+      - skr_splunk_url | length > 0
+      - skr_splunk_token | length > 0
+    fail_msg: "skr_do_send is true but skr_splunk_url or skr_splunk_token is empty"
+
+- name: Create output directory
+  ansible.builtin.file:
+    path: "{{ skr_output_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Build common fields for all events
+  ansible.builtin.set_fact:
+    _skr_common:
+      ocp_version: "{{ skr_report_data.cluster_info.sw_version | default('') }}"
+      ocp_build: "{{ skr_report_data.cluster_info.sw_version | default('') }}"
+      node_name: "{{ skr_spoke_name }}"
+      formal: "{{ skr_formal_test }}"
+      cpu: "{{ skr_report_data.hardware_info.cpu_type | default(skr_report_data.hardware_info.cpu_model | default('')) }}"
+      kernel: "{{ skr_report_data.cluster_info.kernel_version | default('') }}"
+      sideloaded: "{{ '.rt' not in (skr_report_data.cluster_info.kernel_version | default('')) }}"
+
+- name: Build cluster_artifacts dict
+  ansible.builtin.set_fact:
+    _skr_cluster_artifacts:
+      ocp:
+        ocp_version_spoke: "{{ skr_report_data.cluster_info.sw_version | default('') }}"
+        ocp_version_hub: "{{ skr_report_data.cluster_info.hub_version | default('') }}"
+      openshift_version: "{{ skr_report_data.cluster_info.sw_version | default('') }}"
+      kernel_version: "{{ skr_report_data.cluster_info.kernel_version | default('') }}"
+      cpu_model: "{{ skr_report_data.hardware_info.cpu_type | default(skr_report_data.hardware_info.cpu_model | default('')) }}"
+      bios_version: "{{ skr_report_data.hardware_info.bios_version | default('') }}"
+      microcode: "{{ skr_report_data.hardware_info.microcode | default('') }}"
+      architecture: "{{ skr_report_data.hardware_info.architecture | default('') }}"
+      tuned_profile: "{{ skr_report_data.cluster_info.tuned_profile | default('') }}"
+      cluster_name: "{{ skr_cluster_name }}"
+
+- name: Process each test result
+  ansible.builtin.include_tasks: build_and_send.yml
+  loop: "{{ skr_report_data.test_results | dict2items }}"
+  loop_control:
+    loop_var: _skr_test_item
+    label: "{{ _skr_test_item.key }}"
+
+- name: Splunk push summary
+  vars:
+    _skr_search_host: "{{ skr_splunk_url | regex_replace('https?://([^:/]+).*', '\\1') | regex_replace('^splunk-hec\\.', 'splunk.') }}"
+    _skr_test_types: >-
+      {{ skr_report_data.test_results | dict2items
+         | map(attribute='value') | map(attribute='test_type', default='unknown')
+         | list | join(', ') }}
+    _skr_search_query: "index={{ skr_splunk_index }} node_name={{ skr_spoke_name }} | head 20"
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "Splunk Push Summary"
+      - "=========================================="
+      - "Events sent:  {{ skr_report_data.test_results | length }}"
+      - "Test types:   {{ _skr_test_types }}"
+      - "Index:        {{ skr_splunk_index }}"
+      - "Node:         {{ skr_spoke_name }}"
+      - "Formal:       {{ skr_formal_test }}"
+      - "OCP version:  {{ _skr_common.ocp_version | default('') }}"
+      - "Send enabled: {{ skr_do_send }}"
+      - "=========================================="
+      - "Verify Upload"
+      - "=========================================="
+      - "Splunk Web UI search:"
+      - "  https://{{ _skr_search_host }}/en-US/app/search/search?q={{ _skr_search_query | urlencode }}&earliest=-1h"
+      - ""
+      - "CLI verification (run from bastion):"
+      - "  curl -sk -H 'Authorization: Splunk <TOKEN>'"
+      - "    'https://{{ _skr_search_host }}:8089/services/search/jobs/export'"
+      - "    --data-urlencode 'search=search {{ _skr_search_query }}'"
+      - "    -d output_mode=json -d earliest_time=-1h"
+      - ""
+      - "Event JSON files: {{ skr_output_dir }}/"
+      - "=========================================="

--- a/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/send_single_event.yml
+++ b/playbooks/telco-kpis/roles/splunk_kpis_reporter/tasks/send_single_event.yml
@@ -1,0 +1,83 @@
+---
+# Build and send a single Splunk HEC event
+
+- name: Map report status to legacy JUnit status values
+  ansible.builtin.set_fact:
+    _skr_legacy_status: >-
+      {{ {'PASS': 'passed', 'FAIL': 'failed', 'N/A': 'skipped'}[_skr_test_item.value.status | default('')]
+         | default(_skr_test_item.value.status | default('') | lower) }}
+
+- name: Build HEC event payload
+  ansible.builtin.set_fact:
+    _skr_hec_event:
+      host: "{{ skr_splunk_url }}"
+      sourcetype: "_json"
+      event: >-
+        {{ _skr_common | combine({
+          'test_type': _skr_event_fields.test_type | default(_skr_test_type),
+          'status': _skr_legacy_status | trim,
+          'cluster_artifacts': _skr_cluster_artifacts
+        }) | combine(_skr_event_fields) }}
+
+- name: Generate event filename
+  ansible.builtin.set_fact:
+    _skr_event_path: >-
+      {{ skr_output_dir }}/event-{{ _skr_event_fields.test_type
+         | default(_skr_test_type) }}-{{ _skr_test_item.key
+         | hash('md5') | truncate(8, True, '') }}-{{ _skr_event_idx }}.json
+
+- name: Write event to file
+  ansible.builtin.copy:
+    content: "{{ _skr_hec_event | to_nice_json }}"
+    dest: "{{ _skr_event_path }}"
+    mode: '0644'
+
+- name: Display event payload
+  when: skr_debug | bool
+  ansible.builtin.debug:
+    msg: "{{ _skr_hec_event }}"
+
+- name: Show event data types for nested arrays
+  when: skr_debug | bool
+  ansible.builtin.debug:
+    msg: >-
+      Event type={{ _skr_event_fields.test_type | default(_skr_test_type) }},
+      event.event type={{ _skr_hec_event.event | type_debug }},
+      {% if _skr_hec_event.event.Iterations is defined %}
+      Iterations type={{ _skr_hec_event.event.Iterations | type_debug }},
+      Iterations[0] type={{ (_skr_hec_event.event.Iterations[0] | default({})) | type_debug }},
+      total_minutes type={{ (_skr_hec_event.event.Iterations[0].total_minutes | default('N/A')) | type_debug }}
+      {% elif _skr_hec_event.event.scenarios is defined %}
+      scenarios type={{ _skr_hec_event.event.scenarios | type_debug }},
+      scenarios[0] type={{ (_skr_hec_event.event.scenarios[0] | default({})) | type_debug }}
+      {% else %}
+      (no nested arrays)
+      {% endif %}
+
+- name: POST to Splunk HEC (with retries)
+  ansible.builtin.uri:
+    url: "{{ skr_splunk_url }}?index={{ skr_splunk_index }}"
+    method: POST
+    headers:
+      Authorization: "Splunk {{ skr_splunk_token }}"
+    body: "{{ _skr_hec_event }}"
+    body_format: json
+    validate_certs: false
+    timeout: "{{ skr_request_timeout }}"
+    status_code: [200, 201, 202]
+  register: _skr_send_result
+  until: _skr_send_result is not failed
+  retries: "{{ skr_retries }}"
+  delay: "{{ skr_retry_delay }}"
+  when: skr_do_send | bool
+  no_log: "{{ not (skr_debug | bool) }}"
+
+- name: Confirm event sent
+  ansible.builtin.debug:
+    msg: >-
+      Splunk event sent: type={{ _skr_event_fields.test_type | default(_skr_test_type) }}
+      {{ '(reboot_type=' ~ _skr_event_fields.reboot_type ~ ')' if _skr_event_fields.reboot_type is defined else '' }}
+      status={{ _skr_legacy_status | trim }}
+      HTTP={{ _skr_send_result.status | default('dry-run') }}
+      file={{ _skr_event_path | trim }}
+  when: skr_do_send | bool


### PR DESCRIPTION
Enhance oslat, cyclictest, and ZTP parsers with additional fields (min, avg, availability, number_of_nines, deployment_time_seconds) needed by Splunk dashboards. Create splunk_kpis_reporter role that builds HEC events matching the exact legacy event schema (data in event.{fields}, not event.test.{fields}). Includes molecule tests and retry logic for transient HEC failures.