### PR TITLE
Add production repository publishing and force-regeneration support

### DIFF
--- a/playbooks/telco-kpis/generate-report.yml
+++ b/playbooks/telco-kpis/generate-report.yml
@@ -165,23 +165,63 @@
           Run telco-kpis tests with the current environment configuration before generating report.
       when: available_artifacts.files | length == 0
 
-    - name: Check if Gitea repository has existing reports for this spoke
-      block:
-        - name: Set Gitea repository URL (matches gitea role defaults)
-          ansible.builtin.set_fact:
-            gitea_repo_clone_url: "http://{{ ansible_fqdn }}:3000/{{ ansible_user }}/telco-kpis-reports.git"
-            gitea_clone_dir: "/tmp/gitea-freshness-check-{{ spoke_cluster }}-{{ ansible_date_time.epoch }}"
+    - name: Determine report publishing configuration
+      ansible.builtin.set_fact:
+        _report_publish_enabled: "{{ (development_mode | default(false) | bool) or (report_repo_url | default('') | length > 0) }}"
 
-        - name: Clone Gitea repository to check last report timestamp
+    - name: Configure freshness check URL (development mode - Gitea)
+      ansible.builtin.set_fact:
+        _freshness_repo_url: "http://{{ ansible_fqdn }}:3000/{{ ansible_user }}/telco-kpis-reports.git"
+        _freshness_branch: "main"
+      when:
+        - _report_publish_enabled | bool
+        - development_mode | default(false) | bool
+
+    - name: Configure freshness check URL (production repo - token auth)
+      ansible.builtin.set_fact:
+        _freshness_repo_url: >-
+          {{ report_repo_url.split('://')[0] }}://{{
+          report_repo_user | default('oauth2', true) }}:{{
+          report_repo_token }}@{{
+          report_repo_url.split('://')[1] }}
+        _freshness_branch: "{{ report_repo_branch | default('telco-kpis-reports') }}"
+      when:
+        - _report_publish_enabled | bool
+        - not (development_mode | default(false) | bool)
+        - report_repo_token | default('') | length > 0
+      no_log: "{{ ansible_verbosity < 3 }}"
+
+    - name: Configure freshness check URL (production repo - password auth)
+      ansible.builtin.set_fact:
+        _freshness_repo_url: "{{ report_repo_url.split('://')[0] }}://{{ report_repo_user }}:{{ report_repo_password }}@{{ report_repo_url.split('://')[1] }}"
+        _freshness_branch: "{{ report_repo_branch | default('telco-kpis-reports') }}"
+      when:
+        - _report_publish_enabled | bool
+        - not (development_mode | default(false) | bool)
+        - report_repo_token | default('') | length == 0
+        - report_repo_user | default('') | length > 0
+      no_log: "{{ ansible_verbosity < 3 }}"
+
+    - name: Check if report repository has existing reports for this spoke
+      when:
+        - _report_publish_enabled | bool
+        - not (force_report | default(false) | bool)
+      block:
+        - name: Set freshness check clone directory
+          ansible.builtin.set_fact:
+            gitea_clone_dir: "/tmp/report-freshness-check-{{ spoke_cluster }}-{{ ansible_date_time.epoch }}"
+
+        - name: Clone report repository to check last report timestamp
           ansible.builtin.git:
-            repo: "{{ gitea_repo_clone_url }}"
+            repo: "{{ _freshness_repo_url }}"
             dest: "{{ gitea_clone_dir }}"
-            version: main
+            version: "{{ _freshness_branch }}"
             depth: 10
           failed_when: false
           register: gitea_clone_result
           environment:
             GIT_TERMINAL_PROMPT: "0"
+          no_log: "{{ ansible_verbosity < 3 }}"
 
         - name: Get last commit timestamp for this spoke's reports
           ansible.builtin.shell: |
@@ -251,7 +291,7 @@
               - "==========================================="
               - "Test Freshness Check"
               - "==========================================="
-              - "Gitea repository: {{ gitea_repo_clone_url }}"
+              - "Report repository: {{ report_repo_url | default('http://' + ansible_fqdn + ':3000/' + ansible_user + '/telco-kpis-reports.git') }}"
               - "Last report generated: {{ last_report_commit_time.stdout | default('Never', true) }}"
               - "Last report UTC timestamp: {{ last_report_utc_ts.stdout | default('N/A', true) }}"
               - >-
@@ -261,7 +301,7 @@
               - "==========================================="
           when: test_freshness_check is defined
 
-        - name: Cleanup temporary Gitea clone
+        - name: Cleanup temporary freshness check clone
           ansible.builtin.file:
             path: "{{ gitea_clone_dir }}"
             state: absent
@@ -273,6 +313,11 @@
             - test_freshness_check.stdout_lines is defined
             - test_freshness_check.stdout_lines | length > 0
             - test_freshness_check.stdout_lines[-1] == "NO_NEW_TESTS"
+
+    - name: Display force regeneration notice
+      ansible.builtin.debug:
+        msg: "Force report regeneration requested - skipping freshness check"
+      when: force_report | default(false) | bool
 
     - name: Create temporary directory for report output
       ansible.builtin.tempfile:
@@ -338,13 +383,13 @@
         - deployment_timeline_stat.stat.exists
       failed_when: false
 
-    - name: Publish report to Gitea (development mode only)
+    - name: Publish report to repository
       ansible.builtin.include_role:
         name: gitea
       vars:
         report_file: "{{ output_filename }}"
         report_tarball: "{{ tarball_name }}"
-      when: development_mode | default(false) | bool
+      when: _report_publish_enabled | bool
 
     - name: Cleanup temporary output directory
       ansible.builtin.file:

--- a/playbooks/telco-kpis/roles/gitea/defaults/main.yml
+++ b/playbooks/telco-kpis/roles/gitea/defaults/main.yml
@@ -26,3 +26,16 @@ development_mode: false
 
 # Repository retention policy
 gitea_report_retention_days: 7  # Keep reports for last 7 days
+
+# Report publishing branch (overridden by report_repo_branch for production repos)
+report_publish_branch: "main"
+
+# Production/external repository configuration (from vault)
+# When report_repo_url is set and development_mode is false, reports are published
+# to this external repository instead of the local Gitea instance.
+# development_mode always takes precedence for debug/troubleshooting.
+report_repo_url: ""
+report_repo_branch: "telco-kpis-reports"
+report_repo_token: ""
+report_repo_user: ""
+report_repo_password: ""

--- a/playbooks/telco-kpis/roles/gitea/tasks/main.yml
+++ b/playbooks/telco-kpis/roles/gitea/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
 # Main entry point for Gitea role
-# Handles deployment, initialization, and report publishing
+# Supports two publishing modes:
+#   - Development mode (development_mode=true): Deploy local Gitea instance
+#   - Production mode (report_repo_url is set): Publish to external git repo
 
+# === Development mode (local Gitea) - takes precedence ===
 - name: Validate credentials from vault
   ansible.builtin.include_tasks: validate-credentials.yml
   when: development_mode | default(false) | bool
@@ -18,9 +21,18 @@
   ansible.builtin.include_tasks: create-repository.yml
   when: development_mode | default(false) | bool
 
+# === Production mode (external repository) ===
+- name: Setup production repository
+  ansible.builtin.include_tasks: setup-production-repo.yml
+  when:
+    - not (development_mode | default(false) | bool)
+    - report_repo_url | default('') | length > 0
+
+# === Publish report (shared logic for both modes) ===
 - name: Include report publishing tasks
   ansible.builtin.include_tasks: publish-report.yml
   when:
-    - development_mode | default(false) | bool
+    - (development_mode | default(false) | bool) or
+      (report_repo_url | default('') | length > 0)
     - report_file is defined
     - report_tarball is defined

--- a/playbooks/telco-kpis/roles/gitea/tasks/publish-report.yml
+++ b/playbooks/telco-kpis/roles/gitea/tasks/publish-report.yml
@@ -33,10 +33,11 @@
   ansible.builtin.git:
     repo: "{{ gitea_repo_http_url }}"
     dest: "{{ git_work_dir }}"
-    version: main
+    version: "{{ report_publish_branch | default('main') }}"
     force: true
   environment:
     GIT_TERMINAL_PROMPT: "0"
+  no_log: "{{ ansible_verbosity < 3 }}"
 
 - name: Handle report update (remove existing report for today)
   when: report_action | default('update') == 'update'
@@ -240,10 +241,10 @@
   ansible.builtin.set_fact:
     report_list: "{{ found_reports.files | map(attribute='path') | map('regex_replace', git_work_dir + '/reports/', '') | list }}"
 
-- name: Update top-level README.md
+- name: Update reports index README.md
   ansible.builtin.template:
     src: README.md.j2
-    dest: "{{ git_work_dir }}/README.md"
+    dest: "{{ git_work_dir }}/reports/README.md"
     mode: '0644'
 
 - name: Configure git user  # noqa: command-instead-of-module
@@ -277,8 +278,8 @@
   when: git_diff.rc != 0
   changed_when: true
 
-- name: Push to Gitea  # noqa: command-instead-of-module
-  ansible.builtin.command: git push origin main
+- name: Push to repository  # noqa: command-instead-of-module
+  ansible.builtin.command: git push origin {{ report_publish_branch | default('main') }}
   args:
     chdir: "{{ git_work_dir }}"
   when: git_diff.rc != 0
@@ -299,5 +300,10 @@
       - "=========================================="
       - "Spoke: {{ spoke_cluster }}"
       - "Report: {{ report_file }}"
-      - "Web URL: {{ gitea_repo_web_url }}/src/branch/main/reports/{{ report_dir_name }}/{{ spoke_cluster }}"
+      - >-
+        Web URL: {{ gitea_repo_web_url }}{{
+        '/-/tree/' if not (development_mode | default(false) | bool)
+        else '/src/branch/' }}{{
+        report_publish_branch | default('main') }}/reports/{{
+        report_dir_name }}/{{ spoke_cluster }}
       - "=========================================="

--- a/playbooks/telco-kpis/roles/gitea/tasks/setup-production-repo.yml
+++ b/playbooks/telco-kpis/roles/gitea/tasks/setup-production-repo.yml
@@ -1,0 +1,97 @@
+---
+# Setup production/external git repository for report publishing
+# Validates credentials, constructs authenticated URL, and verifies accessibility
+#
+# This task file is used when development_mode is off and report_repo_url is set.
+# It sets the same facts (gitea_repo_http_url, gitea_repo_web_url) that
+# create-repository.yml sets for development mode, so publish-report.yml works
+# identically for both modes.
+
+- name: Display production repository configuration
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "Production Repository Configuration"
+      - "=========================================="
+      - "Repository URL: {{ report_repo_url }}"
+      - "Branch: {{ report_repo_branch | default('main') }}"
+      - "Auth method: {{ 'Token' if (report_repo_token | default('') | length > 0) else 'Password' }}"
+      - "Username: {{ report_repo_user | default('(not set)') }}"
+      - "=========================================="
+
+- name: Validate production repository URL
+  ansible.builtin.assert:
+    that:
+      - report_repo_url | length > 0
+      - report_repo_url is match('^https?://')
+    fail_msg: |
+      Production repository URL is not set or invalid.
+      Expected: HTTPS URL (e.g., https://github.com/org/repo.git)
+      Got: {{ report_repo_url | default('(empty)') }}
+
+- name: Validate authentication credentials
+  ansible.builtin.assert:
+    that:
+      - (report_repo_token | default('') | length > 0) or
+        (report_repo_user | default('') | length > 0 and
+         report_repo_password | default('') | length > 0)
+    fail_msg: |
+      Production repository authentication not configured.
+
+      Provide either:
+        - report_repo_token (preferred)
+        - report_repo_user + report_repo_password (fallback workaround)
+
+      These values should come from vault.
+
+- name: Construct authenticated clone URL (token auth)
+  ansible.builtin.set_fact:
+    gitea_repo_http_url: >-
+      {{ report_repo_url.split('://')[0] }}://{{
+      report_repo_user | default('oauth2', true) }}:{{
+      report_repo_token }}@{{
+      report_repo_url.split('://')[1] }}
+  when: report_repo_token | default('') | length > 0
+  no_log: "{{ ansible_verbosity < 3 }}"
+
+- name: Construct authenticated clone URL (password auth fallback)
+  ansible.builtin.set_fact:
+    gitea_repo_http_url: >-
+      {{ report_repo_url.split('://')[0] }}://{{
+      report_repo_user | default('oauth2', true) }}:{{
+      report_repo_password }}@{{
+      report_repo_url.split('://')[1] }}
+  when: report_repo_token | default('') | length == 0
+  no_log: "{{ ansible_verbosity < 3 }}"
+
+- name: Set production repository metadata
+  ansible.builtin.set_fact:
+    gitea_repo_web_url: "{{ report_repo_url | regex_replace('\\.git$', '') }}"
+    report_publish_branch: "{{ report_repo_branch | default('main') }}"
+    gitea_admin_email: "{{ report_repo_user | default('telco-kpis-automation', true) }}@telco-kpis-ci.redhat.com"
+
+- name: Verify production repository is accessible
+  ansible.builtin.git:
+    repo: "{{ gitea_repo_http_url }}"
+    dest: "/tmp/report-repo-verify-{{ ansible_date_time.epoch }}"
+    version: "{{ report_publish_branch }}"
+    depth: 1
+  register: _repo_verify
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
+  no_log: "{{ ansible_verbosity < 3 }}"
+
+- name: Cleanup verification clone
+  ansible.builtin.file:
+    path: "/tmp/report-repo-verify-{{ ansible_date_time.epoch }}"
+    state: absent
+
+- name: Display production repository verification
+  ansible.builtin.debug:
+    msg:
+      - "=========================================="
+      - "Production Repository Verified"
+      - "=========================================="
+      - "Web URL: {{ gitea_repo_web_url }}"
+      - "Branch: {{ report_publish_branch }}"
+      - "=========================================="

--- a/playbooks/telco-kpis/roles/gitea/templates/README.md.j2
+++ b/playbooks/telco-kpis/roles/gitea/templates/README.md.j2
@@ -11,14 +11,14 @@ This repository contains automated test reports from Telco KPIs verification job
 {%     set date = parts[0] %}
 {%     set spoke = parts[1] %}
 {%     set filename = parts[2] %}
-{%     set _ = ns.reports.append({'date': date, 'spoke': spoke, 'file': filename, 'path': 'reports/' + report_path}) %}
+{%     set _ = ns.reports.append({'date': date, 'spoke': spoke, 'file': filename, 'path': report_path}) %}
 {%   endif %}
 {% endfor %}
 
 | Date | Spoke Cluster | Report | Artifacts |
 |------|---------------|--------|-----------|
 {% for report in ns.reports %}
-| {{ report.date }} | {{ report.spoke }} | [{{ report.file }}]({{ report.path }}) | [Browse](reports/{{ report.date }}/{{ report.spoke }}/) |
+| {{ report.date }} | {{ report.spoke }} | [{{ report.file }}]({{ report.path }}) | [Browse]({{ report.date }}/{{ report.spoke }}/) |
 {% endfor %}
 
 ## Report Structure


### PR DESCRIPTION
Support publishing reports to an external git repository (e.g., GitLab) in addition to the existing local Gitea development mode. Development mode always takes precedence over production repo for debugging.

Production repo auth supports token (oauth2) or user+password fallback, with credentials sourced from HashiCorp Vault. Freshness check extended to work with both modes. Added force_report option to bypass freshness check during development (e.g., to reload Splunk data).