### PR TITLE
Add time-windowed Splunk dashboard links to telco-kpis reports

### DIFF
--- a/playbooks/telco-kpis/generate-report.yml
+++ b/playbooks/telco-kpis/generate-report.yml
@@ -319,6 +319,33 @@
         msg: "Force report regeneration requested - skipping freshness check"
       when: force_report | default(false) | bool
 
+    - name: Compute Splunk report links time window
+      ansible.builtin.shell:
+        cmd: |
+          echo "$(date -u -d '-5 minutes' +%Y-%m-%dT%H:%M:%S.000Z)"
+          echo "$(date -u -d '+15 minutes' +%Y-%m-%dT%H:%M:%S.000Z)"
+        executable: /bin/bash
+      register: _splunk_time_window
+      changed_when: false
+      when: splunk_push_enabled | default(false) | bool
+
+    - name: Configure Splunk report links
+      ansible.builtin.set_fact:
+        splunk_report_links:
+          enabled: true
+          time_earliest: "{{ _splunk_time_window.stdout_lines[0] }}"
+          time_latest: "{{ _splunk_time_window.stdout_lines[1] }}"
+      when:
+        - splunk_push_enabled | default(false) | bool
+        - _splunk_time_window.stdout_lines is defined
+        - _splunk_time_window.stdout_lines | length >= 2
+
+    - name: Disable Splunk report links
+      ansible.builtin.set_fact:
+        splunk_report_links:
+          enabled: false
+      when: not (splunk_push_enabled | default(false) | bool)
+
     - name: Create temporary directory for report output
       ansible.builtin.tempfile:
         state: directory

--- a/playbooks/telco-kpis/roles/report_generator/defaults/main.yml
+++ b/playbooks/telco-kpis/roles/report_generator/defaults/main.yml
@@ -51,6 +51,33 @@ report_generator_parsers:
   ztp_ai_deployment_time: parse_ztp_ai_deployment.yml
   bios_validation: parse_bios_validation.yml
 
+# Splunk dashboard link configuration for reports
+# Each entry maps a test_type to its dashboard name and URL query parameters.
+# Parameter values support placeholders: {ver}, {node}, {kernel}
+report_generator_splunk_base_url: "https://rhcorporate.splunkcloud.com"
+report_generator_splunk_dashboards:
+  oslat:
+    name: "oslat_kpis"
+    params: "form.ocp_view=ocp_build&form.selected_duration=*&form.dashboard_kernels={kernel}"
+  ptp:
+    name: "ptp_kpis"
+    params: "form.bubble_chart_legend=ocp_build&form.test_durations=*&form.dashboard_kernels={kernel}"
+  cyclictest:
+    name: "cyclictest_kpis"
+    params: "form.ocp_view=ocp_build&form.selected_duration=*&form.dashboard_kernels={kernel}"
+  cpu_util:
+    name: "cpu_util_kpis"
+    params: "form.high_cpu_treshhold=0.005&form.selected_duration=*&form.dashboard_kernels={kernel}"
+  reboot:
+    name: "reboot_kpis"
+    params: "form.charts_comparison=ocp_build&form.reboot_type=soft_reboot&form.ocp_build=*&form.dashboard_kernels={kernel}"
+  rfc2544:
+    name: "rfc2544_"
+    params: "form.bubble_chart_legend=kernel&form.histogram={ver}&form.test_durations=*&form.dashboard_kernels={kernel}"
+  ztp_ai_deployment_time:
+    name: "deployment_kpis"
+    params: "form.charts_comparison=ocp_build"
+
 # Default test order in report (matches TEST_TYPES from Python script)
 report_generator_test_order:
   - oslat

--- a/playbooks/telco-kpis/roles/report_generator/molecule/default/prepare.yml
+++ b/playbooks/telco-kpis/roles/report_generator/molecule/default/prepare.yml
@@ -280,8 +280,8 @@
       ansible.builtin.copy:
         content: |
           Comparing clusters...
-          Found 22 CRs with diffs out of 76
-          Found 1 missing CRs
+          CRs with diffs: 22/76
+          1 missing CRs
           Comparison complete
         dest: "{{ shared_artifact_dir }}/rds_compare-{{ spoke_cluster }}-20260706-130300/cluster-compare.log"
         mode: '0644'
@@ -393,6 +393,26 @@
             </testcase>
           </testsuite>
         dest: "{{ shared_artifact_dir }}/bios_validation-{{ spoke_cluster }}-20260706-130500/bios_suite_test.xml"
+        mode: '0644'
+
+    - name: Create mock BIOS Validation JSON report
+      ansible.builtin.copy:
+        content: |
+          {
+            "bios_profile_url": "https://example.com/bios-profile.txt",
+            "results": [
+              {"key": "HyperThreading", "value": "Enabled", "current_value": "Enabled", "status": "PASS"},
+              {"key": "TurboMode", "value": "Disabled", "current_value": "Enabled", "status": "FAIL"},
+              {"key": "VTd", "value": "Enabled", "current_value": "Enabled", "status": "PASS"},
+              {"key": "VTx", "value": "Enabled", "current_value": "Enabled", "status": "PASS"},
+              {"key": "SR-IOV", "value": "Enabled", "current_value": "Enabled", "status": "PASS"},
+              {"key": "C-States", "value": "Disabled", "current_value": "Disabled", "status": "PASS"},
+              {"key": "PackageCStates", "value": "Disabled", "current_value": "Disabled", "status": "PASS"},
+              {"key": "WorkloadProfile", "value": "NUMA", "current_value": "NUMA", "status": "PASS"},
+              {"key": "BootMode", "value": "UEFI", "current_value": "UEFI", "status": "PASS"}
+            ]
+          }
+        dest: "{{ shared_artifact_dir }}/bios_validation-{{ spoke_cluster }}-20260706-130500/bios-validation-report.json"
         mode: '0644'
 
     - name: Create mock ZTP Deployment test directory

--- a/playbooks/telco-kpis/roles/report_generator/molecule/default/verify.yml
+++ b/playbooks/telco-kpis/roles/report_generator/molecule/default/verify.yml
@@ -178,8 +178,8 @@
     - name: Verify BIOS Validation parser shows failure
       ansible.builtin.assert:
         that:
-          - "'P:8 F:1 S:0' in (report_content.content | b64decode)"
-        fail_msg: "BIOS Validation parser did not parse JUnit XML correctly"
+          - "'P:8 F:1' in (report_content.content | b64decode)"
+        fail_msg: "BIOS Validation parser did not extract results from JSON correctly"
         success_msg: "BIOS Validation parser working correctly"
 
     - name: Extract ZTP section from report for debugging # noqa: jinja[spacing]

--- a/playbooks/telco-kpis/roles/report_generator/templates/report.md.j2
+++ b/playbooks/telco-kpis/roles/report_generator/templates/report.md.j2
@@ -50,6 +50,20 @@
 {% endif %}
 {%- endmacro -%}
 
+{%- macro splunk_data_link(test_type) -%}
+{%- if (splunk_report_links | default({})).enabled | default(false) and
+       report_generator_splunk_dashboards[test_type] is defined -%}
+{%- set cfg = report_generator_splunk_dashboards[test_type] -%}
+{%- set t_earliest = splunk_report_links.time_earliest | regex_replace(':', '%3A') -%}
+{%- set t_latest = splunk_report_links.time_latest | regex_replace(':', '%3A') -%}
+{%- set ver = report_data.cluster_info.sw_version | default('') -%}
+{%- set kern = report_data.cluster_info.kernel_version | default('') | regex_replace('\\+', '%2B') -%}
+{%- set extra = cfg.params | default('') | replace('{ver}', ver) | replace('{node}', spoke_cluster) | replace('{kernel}', kern) -%}
+{%- set ocp_build_param = '' if 'form.ocp_build=' in extra else '&form.ocp_build=' ~ ver -%}
+ | [Splunk Data]({{ report_generator_splunk_base_url }}/en-US/app/search/{{ cfg.name }}?form.global_time.earliest={{ t_earliest }}&form.global_time.latest={{ t_latest }}&form.ocp_version={{ ver }}{{ ocp_build_param }}&form.node_name={{ spoke_cluster }}&form.general_statistics={{ ver }}&form.formal_tag=*&{{ extra }})
+{%- endif -%}
+{%- endmacro -%}
+
 # {{ report_generator_title }} - {{ report_data.cluster_info.cluster }}
 
 **Generated:** {{ report_timestamp }}
@@ -119,13 +133,13 @@
 
 {% if output_filename %}
 {%   if result.test_type == 'ztp_ai_deployment_time' %}
-[Deployment Timeline Summary]({{ test_name }}/deployment-timeline-summary.txt) | [Timeline JSON]({{ test_name }}/deployment-timeline.json) | [All artifacts]({{ test_name }}/)
+[Deployment Timeline Summary]({{ test_name }}/deployment-timeline-summary.txt) | [Timeline JSON]({{ test_name }}/deployment-timeline.json){{ splunk_data_link(result.test_type) }} | [All artifacts]({{ test_name }}/)
 {%   elif result.test_type == 'rds_compare' %}
-[Compare Log]({{ test_name }}/cluster-compare.log) | [All artifacts]({{ test_name }}/)
+[Compare Log]({{ test_name }}/cluster-compare.log){{ splunk_data_link(result.test_type) }} | [All artifacts]({{ test_name }}/)
 {%   elif result.test_type == 'bios_validation' %}
-[BIOS Profile]({{ test_name }}/bios-profile.txt) | [Validation Report]({{ test_name }}/bios-validation-report.json) | [All artifacts]({{ test_name }}/)
+[BIOS Profile]({{ test_name }}/bios-profile.txt) | [Validation Report]({{ test_name }}/bios-validation-report.json){{ splunk_data_link(result.test_type) }} | [All artifacts]({{ test_name }}/)
 {%   else %}
-[Raw Log]({{ test_name }}/podman-run.log) | [All artifacts]({{ test_name }}/)
+[Raw Log]({{ test_name }}/podman-run.log){{ splunk_data_link(result.test_type) }} | [All artifacts]({{ test_name }}/)
 {%   endif %}
 {% endif %}
 


### PR DESCRIPTION
When Splunk push is enabled, each test section in the Markdown report includes a "Splunk Data" link to the corresponding dashboard. The time window brackets the upload moment (now-5min to now+15min) so links remain valid. Each dashboard has its own URL parameters matching its actual form fields. No links for rds_compare or bios_validation as those dashboards do not exist.

Also fixes molecule test fixtures: RDS Compare log format to match parser regex, adds missing bios-validation-report.json with correct field names, and corrects the BIOS assertion format.