### PR TITLE
Fix deploy operator so that is uses apply instead of force

### DIFF
--- a/playbooks/deploy-ocp-sno.yml
+++ b/playbooks/deploy-ocp-sno.yml
@@ -657,6 +657,8 @@
         name: redhatci.ocp.destroy_vms
 
     - name: Create VMs
+      vars:
+        additional_virt_install_options: "--boot cdrom,hd"
       ansible.builtin.import_role:
         name: redhatci.ocp.create_vms
 

--- a/playbooks/roles/ocp_operator_deployment/tasks/deploy_operator.yaml
+++ b/playbooks/roles/ocp_operator_deployment/tasks/deploy_operator.yaml
@@ -28,7 +28,8 @@
   kubernetes.core.k8s:
     template: "{{ role_path }}/templates/{{ operator_item.name }}-config.j2"
     state: present
-    force: true
+    server_side_apply:
+      field_manager: ansible
   register: result
   when:
     - operator_item.deploy_default_config is defined


### PR DESCRIPTION
The force:true option triggers a PUT which requires resourceVersion on existing resources, causing failures when the CR already exists (e.g. MultiClusterHub created by the MCE operator). Use server-side apply instead.
